### PR TITLE
feat: optional documentType argument in document upload endpoint

### DIFF
--- a/zaak/src/main/kotlin/com/ritense/portal/zaak/service/ZaakService.kt
+++ b/zaak/src/main/kotlin/com/ritense/portal/zaak/service/ZaakService.kt
@@ -50,5 +50,5 @@ interface ZaakService {
 
     suspend fun getDocumentContent(documentId: UUID): DocumentContent
 
-    suspend fun uploadDocument(file: FilePart): Document
+    suspend fun uploadDocument(file: FilePart, documentType: String?): Document
 }

--- a/zaak/src/main/kotlin/com/ritense/portal/zaak/service/impl/OpenZaakService.kt
+++ b/zaak/src/main/kotlin/com/ritense/portal/zaak/service/impl/OpenZaakService.kt
@@ -120,7 +120,7 @@ class OpenZaakService(
         return DocumentContent(Base64.getEncoder().encodeToString(documentContent))
     }
 
-    override suspend fun uploadDocument(file: FilePart): Document {
+    override suspend fun uploadDocument(file: FilePart, documentType: String?): Document {
         val auteur = ReactiveSecurityContextHolder.getContext()
             .map { (it.authentication as CommonGroundAuthentication).getUserId() }
             .awaitSingleOrNull() ?: "valtimo"
@@ -135,7 +135,7 @@ class OpenZaakService(
                 taal = "nld",
                 bestandsnaam = file.filename(),
                 indicatieGebruiksrecht = false,
-                informatieobjecttype = openZaakClientConfig.documentTypeUrl,
+                informatieobjecttype = documentType ?: openZaakClientConfig.documentTypeUrl,
             ),
             file.content()
         )

--- a/zaak/src/main/kotlin/com/ritense/portal/zaak/web/rest/DocumentContentResource.kt
+++ b/zaak/src/main/kotlin/com/ritense/portal/zaak/web/rest/DocumentContentResource.kt
@@ -37,5 +37,8 @@ interface DocumentContentResource {
     fun downloadStreaming(@PathVariable("documentId") documentId: UUID): ResponseEntity<Flux<DataBuffer>>
 
     @PostMapping(value = ["/document/content"], consumes = [MediaType.MULTIPART_FORM_DATA_VALUE])
-    suspend fun uploadStreaming(@RequestPart("file") file: FilePart): ResponseEntity<Document>
+    suspend fun uploadStreaming(
+        @RequestPart("file") file: FilePart,
+        @RequestPart("informatieobjecttype", required = false) informatieobjecttype: String?
+    ): ResponseEntity<Document>
 }

--- a/zaak/src/main/kotlin/com/ritense/portal/zaak/web/rest/impl/DocumentContentResource.kt
+++ b/zaak/src/main/kotlin/com/ritense/portal/zaak/web/rest/impl/DocumentContentResource.kt
@@ -49,7 +49,10 @@ class DocumentContentResource(
             .body(fileDataStream)
     }
 
-    override suspend fun uploadStreaming(file: FilePart): ResponseEntity<Document> {
-        return ResponseEntity.ok(zaakService.uploadDocument(file))
+    override suspend fun uploadStreaming(
+        file: FilePart,
+        informatieobjecttype: String?
+    ): ResponseEntity<Document> {
+        return ResponseEntity.ok(zaakService.uploadDocument(file, informatieobjecttype))
     }
 }


### PR DESCRIPTION
This PR:
* moves missing document upload endpoint [functionality](https://github.com/valtimo-platform/valtimo-portal-engine/pull/178/) from the old portal-engine repository to this one.