### PR TITLE
feat: objecten api client payload serialization

### DIFF
--- a/app/src/main/resources/config/application.yml
+++ b/app/src/main/resources/config/application.yml
@@ -18,10 +18,6 @@ spring:
         default: dev
     application:
         name: nl-portal-backend-libraries
-    jackson:
-        serialization:
-          write-dates-as-timestamps: false
-        date-format: yyyy-MM-dd'T'HH:mm:ss.SSSZ
     security:
         oauth2:
             resourceserver:

--- a/buildSrc/src/main/kotlin/ApiDependencies.kt
+++ b/buildSrc/src/main/kotlin/ApiDependencies.kt
@@ -21,6 +21,7 @@ object ApiDependencies {
     val graphqlJavaExtendedScalars by lazy { "com.graphql-java:graphql-java-extended-scalars:${ApiVersions.graphqlJava}"}
     val graphqlKotlinHooksProvider by lazy { "com.expediagroup:graphql-kotlin-hooks-provider:${ApiVersions.graphqlKotlin}"}
     val graphqlKotlinSpringServer by lazy { "com.expediagroup:graphql-kotlin-spring-server:${ApiVersions.graphqlKotlin}"}
+    val jacksonBom by lazy { "com.fasterxml.jackson:jackson-bom:${ApiVersions.jacksonBom}" }
     val kotlinLogging by lazy { "io.github.microutils:kotlin-logging:${ApiVersions.kotlinLogging}"}
     val springCloudStream by lazy { "org.springframework.cloud:spring-cloud-stream:${ApiVersions.springCloud}" }
     val springCloudStreamBinderRabbit by lazy { "org.springframework.cloud:spring-cloud-stream-binder-rabbit:${ApiVersions.springCloud}" }

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -34,6 +34,7 @@ object ApiVersions {
     const val commonsIo = "2.13.0"
     const val graphqlJava ="21.0"
     const val graphqlKotlin = "7.0.1"
+    const val jacksonBom = "2.17.2"
     const val kotlinLogging = "3.0.5"
     const val springCloud = "4.0.4"
 }

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -33,8 +33,8 @@ dependencies {
     api("org.springframework.security", "spring-security-oauth2-resource-server")
 
     // Jackson
+    api(ApiDependencies.jacksonBom)
     api("com.fasterxml.jackson.module", "jackson-module-kotlin")
-    api("com.fasterxml.jackson.datatype", "jackson-datatype-jsr310")
 
     // Liquibase
     api("org.liquibase", "liquibase-core")

--- a/core/src/main/kotlin/nl/nlportal/core/autoconfiguration/CoreAutoConfiguration.kt
+++ b/core/src/main/kotlin/nl/nlportal/core/autoconfiguration/CoreAutoConfiguration.kt
@@ -1,0 +1,16 @@
+package nl.nlportal.core.autoconfiguration
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import nl.nlportal.core.util.Mapper
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class CoreAutoConfiguration {
+    @Bean
+    @ConditionalOnMissingBean(name = ["objectMapper"])
+    fun objectMapper(): ObjectMapper {
+        return Mapper.get()
+    }
+}

--- a/core/src/main/kotlin/nl/nlportal/core/autoconfiguration/CoreAutoConfiguration.kt
+++ b/core/src/main/kotlin/nl/nlportal/core/autoconfiguration/CoreAutoConfiguration.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2015-2024 Ritense BV, the Netherlands.
+ *
+ * Licensed under EUPL, Version 1.2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package nl.nlportal.core.autoconfiguration
 
 import com.fasterxml.jackson.databind.ObjectMapper

--- a/core/src/main/kotlin/nl/nlportal/core/util/Mapper.kt
+++ b/core/src/main/kotlin/nl/nlportal/core/util/Mapper.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2023 Ritense BV, the Netherlands.
+ * Copyright 2015-2024 Ritense BV, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/core/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,1 +1,2 @@
 nl.nlportal.core.security.OauthSecurityAutoConfiguration
+nl.nlportal.core.autoconfiguration.CoreAutoConfiguration

--- a/graphql/src/main/kotlin/nl/nlportal/graphql/customtype/ZonedDateTime.kt
+++ b/graphql/src/main/kotlin/nl/nlportal/graphql/customtype/ZonedDateTime.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2015-2024 Ritense BV, the Netherlands.
+ *
+ * Licensed under EUPL, Version 1.2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.nlportal.graphql.customtype
+
+import graphql.language.StringValue
+import graphql.schema.Coercing
+import graphql.schema.CoercingParseLiteralException
+import graphql.schema.CoercingParseValueException
+import graphql.schema.CoercingSerializeException
+import graphql.schema.GraphQLScalarType
+import java.time.ZonedDateTime
+
+object ZonedDateTimeCoercing : Coercing<ZonedDateTime, String> {
+    override fun parseValue(input: Any): ZonedDateTime =
+        when (input is String) {
+            true -> ZonedDateTime.parse(input)
+            else -> throw CoercingParseValueException("Expected valid ZonedDateTime but was $input")
+        }
+
+    override fun parseLiteral(input: Any): ZonedDateTime {
+        when (input is StringValue) {
+            true -> return ZonedDateTime.parse(input.value)
+            else -> throw CoercingParseLiteralException("Expected valid ZonedDateTime literal but was $input")
+        }
+    }
+
+    override fun serialize(dataFetcherResult: Any): String =
+        runCatching {
+            dataFetcherResult.toString()
+        }.getOrElse {
+            throw CoercingSerializeException("Data fetcher result $dataFetcherResult cannot be serialized to a String")
+        }
+}
+
+internal val graphqlZonedDateTimeType =
+    GraphQLScalarType.newScalar()
+        .name("ZonedDateTime")
+        .description("A zoned date time")
+        .coercing(ZonedDateTimeCoercing)
+        .build()

--- a/graphql/src/main/kotlin/nl/nlportal/graphql/hooks/CustomSchemaGeneratorHooks.kt
+++ b/graphql/src/main/kotlin/nl/nlportal/graphql/hooks/CustomSchemaGeneratorHooks.kt
@@ -26,12 +26,14 @@ import graphql.schema.GraphQLType
 import nl.nlportal.graphql.customtype.graphqlBigDecimalType
 import nl.nlportal.graphql.customtype.graphqlBigIntegerType
 import nl.nlportal.graphql.customtype.graphqlLongType
+import nl.nlportal.graphql.customtype.graphqlZonedDateTimeType
 import org.springframework.beans.factory.BeanFactoryAware
 import reactor.core.publisher.Mono
 import java.math.BigDecimal
 import java.math.BigInteger
 import java.time.LocalDate
 import java.time.LocalDateTime
+import java.time.ZonedDateTime
 import java.util.UUID
 import kotlin.reflect.KClass
 import kotlin.reflect.KType
@@ -47,6 +49,7 @@ class CustomSchemaGeneratorHooks(override val wiringFactory: KotlinDirectiveWiri
             ObjectNode::class -> graphqlJSONType
             LocalDate::class -> graphqlLocalDateType
             LocalDateTime::class -> graphqlLocalDateTimeType
+            ZonedDateTime::class -> graphqlZonedDateTimeType
             BigDecimal::class -> graphqlBigDecimalType
             Long::class -> graphqlLongType
             BigInteger::class -> graphqlBigIntegerType

--- a/zgw/documenten-api/src/main/kotlin/nl/nlportal/documentenapi/client/DocumentenApiClient.kt
+++ b/zgw/documenten-api/src/main/kotlin/nl/nlportal/documentenapi/client/DocumentenApiClient.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2023 Ritense BV, the Netherlands.
+ * Copyright 2015-2024 Ritense BV, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/zgw/documenten-api/src/main/kotlin/nl/nlportal/documentenapi/client/DocumentenApiClient.kt
+++ b/zgw/documenten-api/src/main/kotlin/nl/nlportal/documentenapi/client/DocumentenApiClient.kt
@@ -16,7 +16,9 @@
 package nl.nlportal.documentenapi.client
 
 import io.netty.handler.logging.LogLevel
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.reactor.awaitSingleOrNull
+import kotlinx.coroutines.withContext
 import mu.KLogger
 import mu.KotlinLogging
 import nl.nlportal.core.ssl.ClientSslContextResolver
@@ -29,6 +31,7 @@ import org.springframework.http.MediaType
 import org.springframework.http.client.reactive.ReactorClientHttpConnector
 import org.springframework.web.reactive.function.BodyInserters
 import org.springframework.web.reactive.function.client.WebClient
+import org.springframework.web.reactive.function.client.WebClientResponseException
 import org.springframework.web.reactive.function.client.awaitBody
 import reactor.core.publisher.Flux
 import reactor.netty.http.client.HttpClient
@@ -45,12 +48,17 @@ class DocumentenApiClient(
         id: UUID,
         documentApi: String,
     ): Document {
-        var document: Document =
-            webClient(documentApi)
-                .get()
-                .uri("/enkelvoudiginformatieobjecten/$id")
-                .retrieve()
-                .awaitBody()
+        val document: Document =
+            try {
+                webClient(documentApi)
+                    .get()
+                    .uri("/enkelvoudiginformatieobjecten/$id")
+                    .retrieve()
+                    .awaitBody()
+            } catch (e: WebClientResponseException) {
+                logger.error("Could not retrieve document: ${e.responseBodyAsString}", e)
+                throw RuntimeException("Could not retrieve document: ${e.responseBodyAsString}", e)
+            }
         document.documentapi = documentApi
         return document
     }
@@ -86,9 +94,15 @@ class DocumentenApiClient(
     ): Document {
         request.inhoud = UUID.randomUUID().toString()
 
-        val fileData = DataBufferUtils.join(documentContent).awaitSingleOrNull()?.asInputStream()?.readAllBytes()
+        val documentContentStream = DataBufferUtils.join(documentContent).awaitSingleOrNull()?.asInputStream()
 
-        request.inhoud = Base64.getEncoder().encodeToString(fileData)
+        request.inhoud =
+            withContext(Dispatchers.IO) {
+                Base64.getEncoder()
+                    .encodeToString(
+                        documentContentStream?.readAllBytes(),
+                    )
+            }
 
         val response =
             webClient(documentApi)
@@ -107,7 +121,7 @@ class DocumentenApiClient(
     }
 
     private fun webClient(documentApi: String): WebClient {
-        var documentenApiConfig = documentenApiConfigs.getConfig(documentApi)
+        val documentenApiConfig = documentenApiConfigs.getConfig(documentApi)
 
         return WebClient.builder()
             .clientConnector(

--- a/zgw/taak/src/test/resources/config/application.yml
+++ b/zgw/taak/src/test/resources/config/application.yml
@@ -22,7 +22,3 @@ spring:
             resourceserver:
                 jwt:
                     issuer-uri: http://localhost:8082/auth/realms/nlportal
-    jackson:
-        serialization:
-            write-dates-as-timestamps: false
-        date-format: yyyy-MM-dd'T'HH:mm:ss.SSSZ

--- a/zgw/zaken-api/src/test/kotlin/nl/nlportal/zakenapi/service/ZakenApiServiceTest.kt
+++ b/zgw/zaken-api/src/test/kotlin/nl/nlportal/zakenapi/service/ZakenApiServiceTest.kt
@@ -14,8 +14,6 @@ import nl.nlportal.zakenapi.TestHelper.testDocument
 import nl.nlportal.zakenapi.TestHelper.testZaakDocument
 import nl.nlportal.zakenapi.client.ZaakDocumentenConfig
 import nl.nlportal.zakenapi.client.ZakenApiClient
-import nl.nlportal.zakenapi.client.request.SearchZaakInformatieobjectenImpl
-import nl.nlportal.zakenapi.client.request.ZakenInformatieobjectenImpl
 import nl.nlportal.zakenapi.domain.ZaakDocument
 import nl.nlportal.zgw.objectenapi.client.ObjectsApiClient
 import org.junit.jupiter.api.BeforeEach
@@ -39,12 +37,6 @@ class ZakenApiServiceTest {
 
     @Mock(answer = Answers.RETURNS_DEEP_STUBS)
     private lateinit var objectsApiClient: ObjectsApiClient
-
-    @Mock
-    private lateinit var searchZaakInformatieobjectenImpl: SearchZaakInformatieobjectenImpl
-
-    @Mock
-    private lateinit var zakenInformatieobjectenImpl: ZakenInformatieobjectenImpl
 
     @Mock
     private lateinit var documentenApiService: DocumentenApiService
@@ -93,10 +85,8 @@ class ZakenApiServiceTest {
                 )
 
             // given
-            doReturn(zakenInformatieobjectenImpl).whenever(zakenApiClient).zaakInformatieobjecten()
-            doReturn(searchZaakInformatieobjectenImpl).whenever(zakenInformatieobjectenImpl).search()
-            doReturn(searchZaakInformatieobjectenImpl).whenever(searchZaakInformatieobjectenImpl).forZaak(any<String>())
-            doReturn(zaakDocumenten).wheneverBlocking(searchZaakInformatieobjectenImpl) { retrieve() }
+            whenever(zakenApiClient.zaakInformatieobjecten().search().forZaak(any<String>()).retrieve())
+                .thenReturn(zaakDocumenten)
             doReturn(testDocument, *informatieObjecten).wheneverBlocking(documentenApiService) { getDocument(any()) }
 
             // when


### PR DESCRIPTION
This PR:
* fixes LocalDateTime values being serialized into array of members instead of datetimestring
* introduces spring managed objectMapper singleton
* adds new GraphQL type for future use
* include jackson-bom to support all DataTypes out of the box
* fix possible deadlock when handling documentContent in DocumentenApiClient