### PR TITLE
upgrade graphqlKotlin version from 7.0.1 to 8.3.0, because of CVE-202…

### DIFF
--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -34,7 +34,7 @@ object ApiVersions {
     const val commonsIo = "2.17.0"
     const val commonsCodec = "1.17.0"
     const val graphqlJava ="21.0"
-    const val graphqlKotlin = "7.0.1"
+    const val graphqlKotlin = "8.3.0"
     const val jacksonBom = "2.17.2"
     const val kotlinLogging = "7.0.3"
     const val springCloud = "4.1.3"


### PR DESCRIPTION
…4-7254 in protobuf-java dependency