### PR TITLE
fix: publish workflow trigger

### DIFF
--- a/.github/workflows/build-and-publish-artifacts.yml
+++ b/.github/workflows/build-and-publish-artifacts.yml
@@ -45,4 +45,5 @@ jobs:
       VERSION: ${{ needs.detect-variables.outputs.version }}
     runs-on: ubuntu-latest
     steps:
-      - run: echo "::error::Invalid version format. Detected version - \"${VERSION}\". Make sure the version property in gradle.properties is valid."  && exit 1
+      - name: Fail on invalid version
+        run: echo "::error::Invalid version format. Detected version - \"${VERSION}\". Make sure the version property in gradle.properties is valid."  && exit 1

--- a/.github/workflows/build-and-publish-artifacts.yml
+++ b/.github/workflows/build-and-publish-artifacts.yml
@@ -45,4 +45,4 @@ jobs:
       VERSION: ${{ needs.detect-variables.outputs.version }}
     runs-on: ubuntu-latest
     steps:
-      - run: echo "::error::Invalid version format. Detected version - \"${VERSION}\". Make sure the version property in gradle.properties is valid."
+      - run: echo "::error::Invalid version format. Detected version - \"${VERSION}\". Make sure the version property in gradle.properties is valid."  && exit 1

--- a/.github/workflows/build-and-publish-artifacts.yml
+++ b/.github/workflows/build-and-publish-artifacts.yml
@@ -2,11 +2,9 @@ name: Build and Publish Artifacts
 on:
   create:
     branches:
-      - "!**"
       - "release/*"
   push:
     branches:
-      - "!**"
       - "release/*"
 jobs:
   detect-variables:


### PR DESCRIPTION
* make publish workflow only trigger on `release/*` branches
* make it obvious that a publish workflow failed due to an invalid version property