### PR TITLE
fix: version variable detection workflow

### DIFF
--- a/.github/workflows/build-and-publish-artifacts.yml
+++ b/.github/workflows/build-and-publish-artifacts.yml
@@ -22,7 +22,7 @@ jobs:
           echo "VERSION=$PROJECT_VERSION" >> $GITHUB_OUTPUT
       - name: Detect scope
         id: detect-scope
-        run: echo "SCOPE=$(if grep -Eq "^\d+\.\d+\.\d+$" <<< $VERSION ; then echo "RELEASE" ; elif grep -Eq "^\d+\.\d+\.\d+-.*SNAPSHOT$" <<< $VERSION ; then echo "SNAPSHOT" ; else echo "UNKNOWN" ; fi)" >> $GITHUB_OUTPUT
+        run: echo "SCOPE=$(if echo $VERSION | grep -Eq "^\d+\.\d+\.\d+$" ; then echo "RELEASE" ; elif echo $VERSION | grep -Eq "^\d+\.\d+\.\d+-.*SNAPSHOT$" ; then echo "SNAPSHOT" ; else echo "UNKNOWN" ; fi)" >> $GITHUB_OUTPUT
   publish-snapshot:
     needs:
       - detect-variables


### PR DESCRIPTION
* use pipe instead of here string so that the expression matches on versions without new-line as well