### PR TITLE
feat: improve workflows

### DIFF
--- a/.github/workflows/build-and-publish-artifacts.yml
+++ b/.github/workflows/build-and-publish-artifacts.yml
@@ -15,12 +15,12 @@ jobs:
         id: get-project-version
         run: echo "PROJECT_VERSION=$(grep "version" gradle.properties | sed 's/^.*=//')" >> $GITHUB_OUTPUT
       - name: Log project version
-        run: echo "::notice:: Detected project version - \"${{ steps.get-project-version.outputs.PROJECT_VERSION }}\"."
+        run: echo "::notice::Detected project version - \"${{ steps.get-project-version.outputs.PROJECT_VERSION }}\"."
       - name: Detect scope
         id: detect-scope
         run: echo "SCOPE=$(if grep -Pq "^\d+\.\d+\.\d+$" <<< ${{ steps.get-project-version.outputs.PROJECT_VERSION }} ; then echo "RELEASE" ; elif grep -Pq "^\d+\.\d+\.\d+-.*SNAPSHOT$" <<< ${{ steps.get-project-version.outputs.PROJECT_VERSION }} ; then echo "SNAPSHOT" ; else echo "UNKNOWN" ; fi)" >> $GITHUB_OUTPUT
       - name: Log scope
-        run: echo "::notice:: Detected scope - \"${{ steps.detect-scope.outputs.SCOPE }}\"."
+        run: echo "::notice::Detected scope - \"${{ steps.detect-scope.outputs.SCOPE }}\"."
   validate-build:
     uses: ./.github/workflows/validate-build.yml
     permissions: read-all
@@ -49,4 +49,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Fail on invalid version
-        run: echo "::error:: Detected version \"${{ env.VERSION }}\" is neither a RELEASE nor SNAPSHOT. Please make sure the version property in gradle.properties is correct."  && exit 1
+        run: echo "::error::Detected version \"${{ env.VERSION }}\" is neither a RELEASE nor SNAPSHOT. Please make sure the version property in gradle.properties is correct."  && exit 1

--- a/.github/workflows/build-and-publish-artifacts.yml
+++ b/.github/workflows/build-and-publish-artifacts.yml
@@ -8,35 +8,40 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       scope: ${{ steps.detect-scope.outputs.SCOPE }}
-      version: ${{ steps.get-version.outputs.VERSION }}
+      version: ${{ steps.get-project-version.outputs.PROJECT_VERSION }}
     steps:
       - uses: actions/checkout@v4
       - name: Get version from project
-        id: get-version
+        id: get-project-version
         run: |
-          PROJECT_VERSION=$(grep "version" gradle.properties | sed 's/^.*=//')
-          echo "VERSION=$PROJECT_VERSION" >> $GITHUB_ENV
-          echo "VERSION=$PROJECT_VERSION" >> $GITHUB_OUTPUT
+          echo "PROJECT_VERSION=$(grep "version" gradle.properties | sed 's/^.*=//')" >> $GITHUB_OUTPUT
+      - name: Log project version
+        run: echo "::notice:: Detected project version - \"${{ steps.get-project-version.outputs.PROJECT_VERSION }}\"."
       - name: Detect scope
         id: detect-scope
-        env:
-          PROJECT_VERSION: ${{ steps.get-version.outputs.VERSION }}
-        run: echo "SCOPE=$(if echo $PROJECT_VERSION | grep -Eq "^\d+\.\d+\.\d+$" ; then echo "RELEASE" ; elif echo $PROJECT_VERSION | grep -Eq "^\d+\.\d+\.\d+-.*SNAPSHOT$" ; then echo "SNAPSHOT" ; else echo "UNKNOWN" ; fi)" >> $GITHUB_OUTPUT
+        run: echo "SCOPE=$(if grep -Pq "^\d+\.\d+\.\d+$" <<< ${{ steps.get-project-version.outputs.PROJECT_VERSION }} ; then echo "RELEASE" ; elif grep -Pq "^\d+\.\d+\.\d+-.*SNAPSHOT$" <<< ${{ steps.get-project-version.outputs.PROJECT_VERSION }} ; then echo "SNAPSHOT" ; else echo "UNKNOWN" ; fi)" >> $GITHUB_OUTPUT
+      - name: Log scope
+        run: echo "::notice:: Detected scope - \"${{ steps.detect-scope.outputs.SCOPE }}\"."
+  validate-build:
+    uses: ./.github/workflows/validate-build.yml
+    permissions: read-all
   publish-snapshot:
     needs:
       - detect-variables
+      - validate-build
     if: ${{ needs.detect-variables.outputs.scope == 'SNAPSHOT' }}
     uses: ./.github/workflows/publish-snapshot.yml
     secrets: inherit
   publish-release:
     needs:
       - detect-variables
+      - validate-build
     if: ${{ needs.detect-variables.outputs.scope == 'RELEASE' }}
     uses: ./.github/workflows/publish-release.yml
     with:
       artifactVersion: ${{ needs.detect-variables.outputs.version }}
     secrets: inherit
-  unknown:
+  unknown-version:
     needs:
       - detect-variables
     if: ${{ needs.detect-variables.outputs.scope == 'UNKNOWN' }}
@@ -45,4 +50,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Fail on invalid version
-        run: echo "::error::Invalid version format. Detected version - \"${VERSION}\". Make sure the version property in gradle.properties is valid."  && exit 1
+        run: echo "::error:: Detected version \"${{ env.VERSION }}\" is neither a RELEASE nor SNAPSHOT. Please make sure the version property in gradle.properties is correct."  && exit 1

--- a/.github/workflows/build-and-publish-artifacts.yml
+++ b/.github/workflows/build-and-publish-artifacts.yml
@@ -13,8 +13,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Get version from project
         id: get-project-version
-        run: |
-          echo "PROJECT_VERSION=$(grep "version" gradle.properties | sed 's/^.*=//')" >> $GITHUB_OUTPUT
+        run: echo "PROJECT_VERSION=$(grep "version" gradle.properties | sed 's/^.*=//')" >> $GITHUB_OUTPUT
       - name: Log project version
         run: echo "::notice:: Detected project version - \"${{ steps.get-project-version.outputs.PROJECT_VERSION }}\"."
       - name: Detect scope

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -24,8 +24,6 @@ jobs:
           distribution: 'temurin'
       - name: Set up gradle
         uses: gradle/actions/setup-gradle@v4
-      - name: Build with Gradle
-        run: ./gradlew build
       - name: Gradle CheckLicense
         run: ./gradlew checkLicense
       - name: Gradle htmlDependencyReport

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -14,7 +14,6 @@ jobs:
   build-and-publish:
     env:
       JAVA_VERSION: ${{ inputs.javaVersion }}
-      TARGETS: ${{ fromJSON(inputs.targets) }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -25,16 +24,14 @@ jobs:
           distribution: 'temurin'
       - name: Set up gradle
         uses: gradle/actions/setup-gradle@v4
-      - name: Build with Gradle
-        run: ./gradlew build
       - name: Gradle publish Snapshot to Github
-        if: ${{ contains(env.TARGETS,'github-packages') }}
+        if: ${{ contains(fromJSON(inputs.targets),'github-packages') }}
         run: ./gradlew publishDefaultPublicationToGitHubPackagesRepository
         env:
           USER: ${{ secrets.USER }}
           TOKEN: ${{ secrets.TOKEN }}
       - name: Gradle Publish Snapshot to OSS
-        if: ${{ contains(env.TARGETS,'sonatype-snapshots') }}
+        if: ${{ contains(fromJSON(inputs.targets),'sonatype-snapshots') }}
         run: ./gradlew publishDefaultPublicationToSonatypeSnapshotRepository
         env:
           OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}

--- a/.github/workflows/validate-build.yml
+++ b/.github/workflows/validate-build.yml
@@ -12,10 +12,12 @@ on:
     branches:
       - "next-minor"
       - "next-major"
+      - "release/*"
   pull_request:
     branches:
       - "next-minor"
       - "next-major"
+      - "release/*"
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
   cancel-in-progress: true

--- a/.github/workflows/validate-build.yml
+++ b/.github/workflows/validate-build.yml
@@ -7,16 +7,15 @@
 
 name: Validate Build
 on:
+  workflow_call:
   push:
     branches:
       - "next-minor"
       - "next-major"
-      - "release/*"
   pull_request:
     branches:
       - "next-minor"
       - "next-major"
-      - "release/*"
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
   cancel-in-progress: true


### PR DESCRIPTION
This PR improves workflows based on the lessons learned from working with the `release/1.5.x` branch

* make validate-build workflow callable
* run validate-build as a required job before calling publish workflows in the build-and-publish-artifacts workflow