### PR TITLE
- Fixed bug in machtigingsDiensten, when no zaakTypes don't add them …

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -14,4 +14,4 @@ dokkaVersion=2.0.0
 
 org.gradle.jvmargs=-Xmx6g -XX:MaxMetaspaceSize=2048m
 org.gradle.workers.max=10
-version=1.5.1-fix-zaken-api-query-SNAPSHOT
+version=1.5.1-407-fix-zaken-api-query-SNAPSHOT

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,4 +14,4 @@ dokkaVersion=2.0.0
 
 org.gradle.jvmargs=-Xmx6g -XX:MaxMetaspaceSize=2048m
 org.gradle.workers.max=10
-version=1.5.1-fix-machtingdienst-SNAPSHOT
+version=1.5.1-fix-zaken-api-query-SNAPSHOT

--- a/zgw/common-ground-authentication/src/main/kotlin/nl/nlportal/commonground/authentication/AuthenticationMachtigingsDienstService.kt
+++ b/zgw/common-ground-authentication/src/main/kotlin/nl/nlportal/commonground/authentication/AuthenticationMachtigingsDienstService.kt
@@ -53,7 +53,14 @@ class AuthenticationMachtigingsDienstService(
                 zaakTypeList.addAll(machtigingsDienst.zaakTypes)
             }
         }
-        return zaakTypeList
+
+        return when {
+            zaakTypeList.isEmpty() -> {
+                null
+            }
+
+            else -> zaakTypeList
+        }
     }
 
     fun taakTypes(authentication: CommonGroundAuthentication): List<String>? {
@@ -64,7 +71,13 @@ class AuthenticationMachtigingsDienstService(
                 taakTypeList.addAll(machtigingsDienst.taakTypes)
             }
         }
-        return taakTypeList
+        return when {
+            taakTypeList.isEmpty() -> {
+                null
+            }
+
+            else -> taakTypeList
+        }
     }
 
     fun isAllowedZaakType(

--- a/zgw/zaken-api/src/main/kotlin/nl/nlportal/zakenapi/client/request/ZaakRollen.kt
+++ b/zgw/zaken-api/src/main/kotlin/nl/nlportal/zakenapi/client/request/ZaakRollen.kt
@@ -15,6 +15,8 @@ interface SearchZaakRollen : PagedRetrieve<SearchZaakRollen, ZaakRol>, Authentic
     fun forZaak(zaakId: UUID): SearchZaakRollen
 
     fun ofVestigingsNummer(vestigingsNummer: String): SearchZaakRollen
+
+    fun withOmschrijvingGeneriek(): SearchZaakRollen
 }
 
 interface GetZaakRol : Retrieve<ZaakRol>

--- a/zgw/zaken-api/src/main/kotlin/nl/nlportal/zakenapi/client/request/ZaakRollenImpl.kt
+++ b/zgw/zaken-api/src/main/kotlin/nl/nlportal/zakenapi/client/request/ZaakRollenImpl.kt
@@ -81,6 +81,11 @@ class SearchRollenImpl(val zakenApiClient: ZakenApiClient) : SearchZaakRollen {
         return this
     }
 
+    override fun withOmschrijvingGeneriek(): SearchZaakRollen {
+        queryParams.add("omschrijvingGeneriek", "initiator")
+        return this
+    }
+
     override suspend fun retrieve(): ResultPage<ZaakRol> {
         return this.zakenApiClient.webClient.get()
             .uri { it.path("/zaken/api/v1/rollen").queryParams(queryParams).build() }

--- a/zgw/zaken-api/src/main/kotlin/nl/nlportal/zakenapi/client/request/Zaken.kt
+++ b/zgw/zaken-api/src/main/kotlin/nl/nlportal/zakenapi/client/request/Zaken.kt
@@ -18,7 +18,7 @@ interface SearchZaken : PagedRetrieve<SearchZaken, Zaak>, AuthenticationFilter<S
 
     fun ofIdentificatie(identificatie: String): SearchZaken
 
-    fun withOmschrijvingGeneriek(): SearchZaken
+    fun withRolOmschrijvingGeneriek(): SearchZaken
 }
 
 interface GetZaak : Retrieve<Zaak>

--- a/zgw/zaken-api/src/main/kotlin/nl/nlportal/zakenapi/client/request/Zaken.kt
+++ b/zgw/zaken-api/src/main/kotlin/nl/nlportal/zakenapi/client/request/Zaken.kt
@@ -17,6 +17,8 @@ interface SearchZaken : PagedRetrieve<SearchZaken, Zaak>, AuthenticationFilter<S
     fun isOpen(open: Boolean): SearchZaken
 
     fun ofIdentificatie(identificatie: String): SearchZaken
+
+    fun withOmschrijvingGeneriek(): SearchZaken
 }
 
 interface GetZaak : Retrieve<Zaak>

--- a/zgw/zaken-api/src/main/kotlin/nl/nlportal/zakenapi/client/request/ZakenImpl.kt
+++ b/zgw/zaken-api/src/main/kotlin/nl/nlportal/zakenapi/client/request/ZakenImpl.kt
@@ -86,6 +86,11 @@ class SearchZakenImpl(val zakenApiClient: ZakenApiClient) : SearchZaken {
         return this
     }
 
+    override fun withOmschrijvingGeneriek(): SearchZaken {
+        queryParams.add("rol__omschrijvingGeneriek", "initiator")
+        return this
+    }
+
     override suspend fun retrieve(): ResultPage<Zaak> {
         return this.zakenApiClient.webClient.get()
             .uri { it.path("/zaken/api/v1/zaken").queryParams(queryParams).build() }

--- a/zgw/zaken-api/src/main/kotlin/nl/nlportal/zakenapi/client/request/ZakenImpl.kt
+++ b/zgw/zaken-api/src/main/kotlin/nl/nlportal/zakenapi/client/request/ZakenImpl.kt
@@ -86,7 +86,7 @@ class SearchZakenImpl(val zakenApiClient: ZakenApiClient) : SearchZaken {
         return this
     }
 
-    override fun withOmschrijvingGeneriek(): SearchZaken {
+    override fun withRolOmschrijvingGeneriek(): SearchZaken {
         queryParams.add("rol__omschrijvingGeneriek", "initiator")
         return this
     }

--- a/zgw/zaken-api/src/main/kotlin/nl/nlportal/zakenapi/client/request/ZoekenImpl.kt
+++ b/zgw/zaken-api/src/main/kotlin/nl/nlportal/zakenapi/client/request/ZoekenImpl.kt
@@ -85,6 +85,11 @@ class SearchZoekenImpl(val zakenApiClient: ZakenApiClient) : SearchZaken {
         return this
     }
 
+    override fun withOmschrijvingGeneriek(): SearchZaken {
+        bodyValue.add("rol__omschrijvingGeneriek", "initiator")
+        return this
+    }
+
     override suspend fun retrieve(): ResultPage<Zaak> {
         return this.zakenApiClient.webClient
             .post()

--- a/zgw/zaken-api/src/main/kotlin/nl/nlportal/zakenapi/client/request/ZoekenImpl.kt
+++ b/zgw/zaken-api/src/main/kotlin/nl/nlportal/zakenapi/client/request/ZoekenImpl.kt
@@ -85,7 +85,7 @@ class SearchZoekenImpl(val zakenApiClient: ZakenApiClient) : SearchZaken {
         return this
     }
 
-    override fun withOmschrijvingGeneriek(): SearchZaken {
+    override fun withRolOmschrijvingGeneriek(): SearchZaken {
         bodyValue.add("rol__omschrijvingGeneriek", "initiator")
         return this
     }

--- a/zgw/zaken-api/src/main/kotlin/nl/nlportal/zakenapi/service/ZakenApiService.kt
+++ b/zgw/zaken-api/src/main/kotlin/nl/nlportal/zakenapi/service/ZakenApiService.kt
@@ -58,7 +58,7 @@ class ZakenApiService(
                 .search()
                 .page(page)
                 .withAuthentication(authentication)
-                .withOmschrijvingGeneriek()
+                .withRolOmschrijvingGeneriek()
 
         pageSize?.let { request.pageSize(it) }
         zaakTypeUrl?.let { request.ofZaakType(it) }

--- a/zgw/zaken-api/src/main/kotlin/nl/nlportal/zakenapi/service/ZakenApiService.kt
+++ b/zgw/zaken-api/src/main/kotlin/nl/nlportal/zakenapi/service/ZakenApiService.kt
@@ -58,6 +58,7 @@ class ZakenApiService(
                 .search()
                 .page(page)
                 .withAuthentication(authentication)
+                .withOmschrijvingGeneriek()
 
         pageSize?.let { request.pageSize(it) }
         zaakTypeUrl?.let { request.ofZaakType(it) }
@@ -88,6 +89,7 @@ class ZakenApiService(
                 .search()
                 .forZaak(id)
                 .withAuthentication(authentication)
+                .withOmschrijvingGeneriek()
 
         val rollen: List<ZaakRol> =
             zaakRollenRequest


### PR DESCRIPTION
…to the query causing in no results.

- Add omschrijvingGeneriek for 'initiator' to the getZaken query. To prevent certain roltypes to be able to see the Zaak