### PR TITLE
feat: removed /engine-rest from client decision endpoint, should be c…

### DIFF
--- a/product/src/main/kotlin/nl/nlportal/product/client/DmnClient.kt
+++ b/product/src/main/kotlin/nl/nlportal/product/client/DmnClient.kt
@@ -92,7 +92,7 @@ class DmnClient(
     suspend fun getDecision(dmnRequest: DmnRequest): List<Map<String, DmnResponse>> {
         return webClient
             .post()
-            .uri("/engine-rest/decision-definition/key/${dmnRequest.key}/evaluate")
+            .uri("/decision-definition/key/${dmnRequest.key}/evaluate")
             .contentType(MediaType.APPLICATION_JSON)
             .accept(MediaType.APPLICATION_JSON)
             .body(

--- a/product/src/test/kotlin/nl/nlportal/product/graphql/ProductQueryIT.kt
+++ b/product/src/test/kotlin/nl/nlportal/product/graphql/ProductQueryIT.kt
@@ -479,7 +479,7 @@ internal class ProductQueryIT(
                             "GET /api/v2/objects/2d725c07-2f26-4705-8637-438a42b5ac2d" -> {
                                 TestHelper.mockResponseFromFile("/product/data/get-product.json")
                             }
-                            "POST /engine-rest/decision-definition/key/watkanikregelenDmn/evaluate" -> {
+                            "POST /decision-definition/key/watkanikregelenDmn/evaluate" -> {
                                 TestHelper.mockResponseFromFile("/product/data/get-dmn-decision.json")
                             }
                             else -> MockResponse().setResponseCode(404)


### PR DESCRIPTION
…onfigured in the baseUrl in the properties

Something went wrong with previous PR, so another try ;-)