### PR TITLE
feat: add a global graphql exception handler.

### DIFF
--- a/graphql/src/main/kotlin/nl/nlportal/graphql/GraphQLExceptionHandler.kt
+++ b/graphql/src/main/kotlin/nl/nlportal/graphql/GraphQLExceptionHandler.kt
@@ -19,9 +19,7 @@ import graphql.GraphQLError
 import graphql.GraphqlErrorBuilder
 import graphql.schema.DataFetchingEnvironment
 import org.springframework.graphql.execution.DataFetcherExceptionResolverAdapter
-import org.springframework.stereotype.Component
 
-@Component
 class GraphQLExceptionHandler : DataFetcherExceptionResolverAdapter() {
     override fun resolveToSingleError(
         ex: Throwable,

--- a/graphql/src/main/kotlin/nl/nlportal/graphql/GraphQLExceptionHandler.kt
+++ b/graphql/src/main/kotlin/nl/nlportal/graphql/GraphQLExceptionHandler.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2025 Ritense BV, the Netherlands.
+ *
+ * Licensed under EUPL, Version 1.2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.nlportal.graphql
+
+import graphql.GraphQLError
+import graphql.GraphqlErrorBuilder
+import graphql.schema.DataFetchingEnvironment
+import org.springframework.graphql.execution.DataFetcherExceptionResolverAdapter
+import org.springframework.stereotype.Component
+
+@Component
+class GraphQLExceptionHandler : DataFetcherExceptionResolverAdapter() {
+    override fun resolveToSingleError(
+        ex: Throwable,
+        env: DataFetchingEnvironment,
+    ): GraphQLError? =
+        GraphqlErrorBuilder
+            .newError()
+            .message(ex.message)
+            .path(env.executionStepInfo.path)
+            .location(env.field.sourceLocation)
+            .build()
+}

--- a/graphql/src/main/kotlin/nl/nlportal/graphql/GraphqlAutoConfiguration.kt
+++ b/graphql/src/main/kotlin/nl/nlportal/graphql/GraphqlAutoConfiguration.kt
@@ -20,6 +20,7 @@ import graphql.schema.idl.RuntimeWiring
 import nl.nlportal.graphql.customtype.graphqlLocalDateTimeType
 import nl.nlportal.graphql.customtype.graphqlZonedDateTimeType
 import org.springframework.boot.autoconfigure.AutoConfiguration
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.context.annotation.Bean
 import org.springframework.graphql.execution.RuntimeWiringConfigurer
 
@@ -42,4 +43,8 @@ class GraphqlAutoConfiguration {
                 .scalar(graphqlZonedDateTimeType)
                 .scalar(graphqlLocalDateTimeType)
         }
+
+    @Bean
+    @ConditionalOnMissingBean(GraphQLExceptionHandler::class)
+    fun graphQLExceptionHandler() = GraphQLExceptionHandler()
 }

--- a/graphql/src/main/resources/graphql/schemas.graphqls
+++ b/graphql/src/main/resources/graphql/schemas.graphqls
@@ -14,3 +14,7 @@ scalar PositiveFloat
 scalar LocalTime
 scalar DateTime
 scalar Locale
+scalar LocalDateTime
+scalar Long
+scalar BigDecimal
+scalar BigInteger


### PR DESCRIPTION
- add a global graphql exception handler
- move base schemas.graphql file from app to graphql module. All implementations should extend the query and mutations in their schemas.graphql file
- added all the available extended scalars