### PR TITLE
feat: downgrade spotless to 7.2.1, because current JReleaser version …

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ kotlinVersion=2.3.0
 springBootVersion=3.5.9
 springDependencyManagementVersion=1.1.7
 benManesVersionsVersion=0.53.0
-spotlessVersion=8.2.1
+spotlessVersion=7.2.1
 gradleDockerComposeVersion=0.17.20
 
 org.gradle.jvmargs=-Xmx6g -XX:MaxMetaspaceSize=2048m


### PR DESCRIPTION
…doesn't support spotless v8.