### PR TITLE
Fix for error "No setter found for property: brp-fields"

### DIFF
--- a/haalcentraal2/src/main/kotlin/nl/nlportal/haalcentraal2/autoconfiguration/HaalCentraal2ModuleConfiguration.kt
+++ b/haalcentraal2/src/main/kotlin/nl/nlportal/haalcentraal2/autoconfiguration/HaalCentraal2ModuleConfiguration.kt
@@ -37,7 +37,7 @@ class HaalCentraal2ModuleConfiguration {
         var apiKey: String? = null
         var additionalHeaders: Map<String, String> = emptyMap()
         var ssl: Ssl? = null
-        val brpFields: List<String> =
+        var brpFields: List<String> =
             listOf(
                 "aNummer",
                 "adressering",


### PR DESCRIPTION
Fix for "No setter found for property: brp-fields" when limiting the brp fields with application.yml or environment variables