### PR TITLE
Add ArchUnit guard requiring CommonGroundAuthentication on graphql operations

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -44,6 +44,8 @@ dependencies {
     api("org.postgresql:postgresql")
 
     testImplementation(project(":zgw:common-ground-authentication-test"))
+    testImplementation(project(":case"))
+    testImplementation(TestDependencies.archUnitJunit5)
     testImplementation(TestDependencies.postgresql)
     testImplementation(TestDependencies.springBootTest)
     testImplementation(TestDependencies.springSecurityTest)

--- a/app/src/test/kotlin/nl/nlportal/app/architecture/GraphQlOperationAuthenticationArchTest.kt
+++ b/app/src/test/kotlin/nl/nlportal/app/architecture/GraphQlOperationAuthenticationArchTest.kt
@@ -25,6 +25,7 @@ import com.tngtech.archunit.lang.ArchCondition
 import com.tngtech.archunit.lang.ConditionEvents
 import com.tngtech.archunit.lang.SimpleConditionEvent
 import com.tngtech.archunit.lang.syntax.ArchRuleDefinition.methods
+import nl.nlportal.commonground.authentication.CommonGroundAuthentication
 import org.junit.jupiter.api.Test
 import org.springframework.graphql.data.method.annotation.MutationMapping
 import org.springframework.graphql.data.method.annotation.QueryMapping
@@ -69,6 +70,6 @@ class GraphQlOperationAuthenticationArchTest {
 
     companion object {
         private const val BASE_PACKAGE = "nl.nlportal"
-        private const val AUTHENTICATION_TYPE = "nl.nlportal.commonground.authentication.CommonGroundAuthentication"
+        private val AUTHENTICATION_TYPE = CommonGroundAuthentication::class.java.name
     }
 }

--- a/app/src/test/kotlin/nl/nlportal/app/architecture/GraphQlOperationAuthenticationArchTest.kt
+++ b/app/src/test/kotlin/nl/nlportal/app/architecture/GraphQlOperationAuthenticationArchTest.kt
@@ -40,10 +40,17 @@ class GraphQlOperationAuthenticationArchTest {
     fun `graphql query and mutation methods must declare a CommonGroundAuthentication parameter`() {
         methods()
             .that(annotatedWithQueryOrMutationMapping())
-            .and().doNotHaveModifier(JavaModifier.SYNTHETIC)
-            .and().areDeclaredInClassesThat().areAnnotatedWith(Controller::class.java)
-            .and().areDeclaredInClassesThat().resideInAPackage("..graphql..")
-            .and().areDeclaredInClassesThat().haveSimpleNameNotEndingWith("DefinitionQuery")
+            .and()
+            .doNotHaveModifier(JavaModifier.SYNTHETIC)
+            .and()
+            .areDeclaredInClassesThat()
+            .areAnnotatedWith(Controller::class.java)
+            .and()
+            .areDeclaredInClassesThat()
+            .resideInAPackage("..graphql..")
+            .and()
+            .areDeclaredInClassesThat()
+            .haveSimpleNameNotEndingWith("DefinitionQuery")
             .should(declareCommonGroundAuthenticationParameter())
             .check(importedClasses)
     }
@@ -55,7 +62,10 @@ class GraphQlOperationAuthenticationArchTest {
 
     private fun declareCommonGroundAuthenticationParameter(): ArchCondition<JavaMethod> =
         object : ArchCondition<JavaMethod>("declare a parameter of type $AUTHENTICATION_TYPE") {
-            override fun check(method: JavaMethod, events: ConditionEvents) {
+            override fun check(
+                method: JavaMethod,
+                events: ConditionEvents,
+            ) {
                 val hasAuthentication = method.rawParameterTypes.any { it.fullName == AUTHENTICATION_TYPE }
                 if (!hasAuthentication) {
                     events.add(

--- a/app/src/test/kotlin/nl/nlportal/app/architecture/GraphQlOperationAuthenticationArchTest.kt
+++ b/app/src/test/kotlin/nl/nlportal/app/architecture/GraphQlOperationAuthenticationArchTest.kt
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2025 Ritense BV, the Netherlands.
+ *
+ * Licensed under EUPL, Version 1.2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.nlportal.app.architecture
+
+import com.tngtech.archunit.base.DescribedPredicate
+import com.tngtech.archunit.core.domain.JavaClasses
+import com.tngtech.archunit.core.domain.JavaMethod
+import com.tngtech.archunit.core.domain.JavaModifier
+import com.tngtech.archunit.core.domain.properties.CanBeAnnotated.Predicates.annotatedWith
+import com.tngtech.archunit.core.importer.ClassFileImporter
+import com.tngtech.archunit.lang.ArchCondition
+import com.tngtech.archunit.lang.ConditionEvents
+import com.tngtech.archunit.lang.SimpleConditionEvent
+import com.tngtech.archunit.lang.syntax.ArchRuleDefinition.methods
+import org.junit.jupiter.api.Test
+import org.springframework.graphql.data.method.annotation.MutationMapping
+import org.springframework.graphql.data.method.annotation.QueryMapping
+import org.springframework.stereotype.Controller
+
+class GraphQlOperationAuthenticationArchTest {
+    private val importedClasses: JavaClasses = ClassFileImporter().importPackages(BASE_PACKAGE)
+
+    // Definition queries (e.g. FormDefinitionQuery, CaseDefinitionQuery) only return schema/definition
+    // metadata, not citizen data, so they are intentionally unauthenticated.
+    @Test
+    fun `graphql query and mutation methods must declare a CommonGroundAuthentication parameter`() {
+        methods()
+            .that(annotatedWithQueryOrMutationMapping())
+            .and().doNotHaveModifier(JavaModifier.SYNTHETIC)
+            .and().areDeclaredInClassesThat().areAnnotatedWith(Controller::class.java)
+            .and().areDeclaredInClassesThat().resideInAPackage("..graphql..")
+            .and().areDeclaredInClassesThat().haveSimpleNameNotEndingWith("DefinitionQuery")
+            .should(declareCommonGroundAuthenticationParameter())
+            .check(importedClasses)
+    }
+
+    private fun annotatedWithQueryOrMutationMapping(): DescribedPredicate<JavaMethod> =
+        annotatedWith(QueryMapping::class.java)
+            .or(annotatedWith(MutationMapping::class.java))
+            .forSubtype()
+
+    private fun declareCommonGroundAuthenticationParameter(): ArchCondition<JavaMethod> =
+        object : ArchCondition<JavaMethod>("declare a parameter of type $AUTHENTICATION_TYPE") {
+            override fun check(method: JavaMethod, events: ConditionEvents) {
+                val hasAuthentication = method.rawParameterTypes.any { it.fullName == AUTHENTICATION_TYPE }
+                if (!hasAuthentication) {
+                    events.add(
+                        SimpleConditionEvent.violated(
+                            method,
+                            "${method.fullName} does not declare a $AUTHENTICATION_TYPE parameter",
+                        ),
+                    )
+                }
+            }
+        }
+
+    companion object {
+        private const val BASE_PACKAGE = "nl.nlportal"
+        private const val AUTHENTICATION_TYPE = "nl.nlportal.commonground.authentication.CommonGroundAuthentication"
+    }
+}

--- a/buildSrc/src/main/kotlin/TestDependencies.kt
+++ b/buildSrc/src/main/kotlin/TestDependencies.kt
@@ -15,6 +15,7 @@
  */
 
 object TestDependencies {
+    val archUnitJunit5 by lazy { "com.tngtech.archunit:archunit-junit5:${Versions.archUnit}" }
     val hamcrest by lazy { "org.hamcrest:hamcrest:${Versions.hamcrest}" }
     val kotlinCoroutines by lazy { "org.jetbrains.kotlinx:kotlinx-coroutines-test:${Versions.kotlinCoroutines}"}
     val mockitoKotlin by lazy { "org.mockito.kotlin:mockito-kotlin:${Versions.mockitoKotlin}" }

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -30,6 +30,7 @@ object Versions {
     const val springCloud = "4.3.0"
 
     //Test versions
+    const val archUnit = "1.3.0"
     const val hamcrest = "3.0"
     const val mockitoKotlin = "6.1.0"
     const val okHttp3 = "5.2.0"

--- a/zgw/verificatie/src/main/kotlin/nl/nlportal/verificatie/graphql/VerificatieMutation.kt
+++ b/zgw/verificatie/src/main/kotlin/nl/nlportal/verificatie/graphql/VerificatieMutation.kt
@@ -31,6 +31,7 @@ class VerificatieMutation(
 ) {
     @MutationMapping
     suspend fun createVerificatie(
+        authentication: CommonGroundAuthentication,
         @Argument verificatieCreateInput: VerificatieCreateInput,
     ): VerificatieCreateResponse =
         verificatieService.createVerificatie(

--- a/zgw/verificatie/src/main/kotlin/nl/nlportal/verificatie/graphql/VerificatieQuery.kt
+++ b/zgw/verificatie/src/main/kotlin/nl/nlportal/verificatie/graphql/VerificatieQuery.kt
@@ -15,6 +15,7 @@
  */
 package nl.nlportal.verificatie.graphql
 
+import nl.nlportal.commonground.authentication.CommonGroundAuthentication
 import nl.nlportal.verificatie.autoconfigure.VerificatieModuleConfiguration
 import nl.nlportal.verificatie.graphql.domain.VerificationConfig
 import org.springframework.graphql.data.method.annotation.QueryMapping
@@ -25,7 +26,7 @@ class VerificatieQuery(
     val verificatieModuleConfiguration: VerificatieModuleConfiguration,
 ) {
     @QueryMapping
-    fun verificatieConfig(): VerificationConfig =
+    fun verificatieConfig(authentication: CommonGroundAuthentication): VerificationConfig =
         VerificationConfig(
             enabled = verificatieModuleConfiguration.enabled,
             typesNeedVerification = verificatieModuleConfiguration.properties.typesNeedVerification,


### PR DESCRIPTION
## Summary
- Add ArchUnit architecture test (`app` module) asserting every `@QueryMapping`/`@MutationMapping` declared in a `@Controller` under a `..graphql..` package declares a `CommonGroundAuthentication` parameter.
- Exclude public `*DefinitionQuery` controllers (form/case definitions return schema/definition metadata, not citizen data) and Kotlin synthetic `$suspendImpl` methods.
- Fix two missing-auth operations the guard caught:
  - `VerificatieQuery.verificatieConfig`
  - `VerificatieMutation.createVerificatie`
- Wire ArchUnit 1.3.0 via `Versions`/`TestDependencies`; add `:case` as an `app` test dependency so its graphql controllers are on the classpath.

## Test plan
- [ ] `./gradlew :app:test --tests "nl.nlportal.app.architecture.GraphQlOperationAuthenticationArchTest"` passes
- [ ] Verificatie integration tests still pass (`verificatieConfig`/`createVerificatie` now resolve auth from context)