### PR TITLE
feat: rework form module

### DIFF
--- a/buildSrc/src/main/kotlin/TestDependencies.kt
+++ b/buildSrc/src/main/kotlin/TestDependencies.kt
@@ -22,6 +22,7 @@ object TestDependencies {
     val okHttpMockWebserver by lazy { "com.squareup.okhttp3:mockwebserver:${Versions.okHttp3}" }
     val okHttpTls by lazy { "com.squareup.okhttp3:okhttp-tls:${Versions.okHttp3}" }
     val postgresql by lazy { "org.postgresql:postgresql:${Versions.postgresql}" }
+    val h2 by lazy { "com.h2database:h2:${Versions.h2}" }
     val springBootTest by lazy {"org.springframework.boot:spring-boot-starter-test"}
     val springSecurityTest by lazy {"org.springframework.security:spring-security-test"}
     val assertJCore by lazy { "org.assertj:assertj-core" }

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -33,4 +33,5 @@ object Versions {
     const val mockitoKotlin = "6.1.0"
     const val okHttp3 = "5.2.0"
     const val postgresql = "42.7.8"
+    const val h2 = "2.3.232"
 }

--- a/form/build.gradle.kts
+++ b/form/build.gradle.kts
@@ -29,6 +29,7 @@ dependencies {
     api(project(":data"))
     api(project(":graphql"))
     api(project(":zgw:objectenapi"))
+    api(project(":zgw:common-ground-authentication"))
 
     implementation(Dependencies.kotlinCoroutines)
     implementation(Dependencies.kotlinCoroutinesReactor)

--- a/form/src/main/kotlin/nl/nlportal/form/autoconfigure/FormAutoConfiguration.kt
+++ b/form/src/main/kotlin/nl/nlportal/form/autoconfigure/FormAutoConfiguration.kt
@@ -27,6 +27,7 @@ import org.springframework.boot.autoconfigure.AutoConfiguration
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.boot.autoconfigure.domain.EntityScan
+import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean
 import org.springframework.core.io.ResourceLoader
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories
@@ -34,6 +35,7 @@ import org.springframework.data.jpa.repository.config.EnableJpaRepositories
 @AutoConfiguration
 @EnableJpaRepositories(basePackages = ["nl.nlportal.form.repository"])
 @EntityScan("nl.nlportal.form.domain")
+@EnableConfigurationProperties(FormConfig::class)
 @ConditionalOnProperty(prefix = "nl-portal.config", name = ["objectenapi.enabled"], havingValue = "true")
 class FormAutoConfiguration {
     @Bean
@@ -48,7 +50,10 @@ class FormAutoConfiguration {
 
     @Bean
     @ConditionalOnMissingBean(ObjectsApiFormDefinitionService::class)
-    fun objectsApiFormDefinitionService(objectenApiService: ObjectenApiService): ObjectsApiFormDefinitionService = ObjectsApiFormDefinitionService(objectenApiService)
+    fun objectsApiFormDefinitionService(
+        objectenApiService: ObjectenApiService,
+        formConfig: FormConfig,
+    ): ObjectsApiFormDefinitionService = ObjectsApiFormDefinitionService(objectenApiService, formConfig)
 
     @Bean
     @ConditionalOnMissingBean(FormDefinitionDeploymentService::class)
@@ -63,6 +68,5 @@ class FormAutoConfiguration {
     @Bean
     fun formDefinitionQuery(
         formIoFormDefinitionService: FormIoFormDefinitionService,
-        objectenApiFormDefinitionService: ObjectsApiFormDefinitionService,
-    ): FormDefinitionQuery = FormDefinitionQuery(formIoFormDefinitionService, objectenApiFormDefinitionService)
+    ): FormDefinitionQuery = FormDefinitionQuery(formIoFormDefinitionService)
 }

--- a/form/src/main/kotlin/nl/nlportal/form/autoconfigure/FormConfig.kt
+++ b/form/src/main/kotlin/nl/nlportal/form/autoconfigure/FormConfig.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2015-2025 Ritense BV, the Netherlands.
+ *
+ * Licensed under EUPL, Version 1.2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.nlportal.form.autoconfigure
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+@ConfigurationProperties(prefix = "nl-portal.config.form")
+class FormConfig {
+    var properties: FormConfigProperties = FormConfigProperties()
+
+    class FormConfigProperties {
+        var formDefinitionObjectTypeUrl: String? = null
+    }
+}

--- a/form/src/main/kotlin/nl/nlportal/form/graphql/FormDefinitionQuery.kt
+++ b/form/src/main/kotlin/nl/nlportal/form/graphql/FormDefinitionQuery.kt
@@ -15,9 +15,8 @@
  */
 package nl.nlportal.form.graphql
 
-import java.util.UUID.fromString
+import nl.nlportal.commonground.authentication.CommonGroundAuthentication
 import nl.nlportal.form.service.FormIoFormDefinitionService
-import nl.nlportal.form.service.ObjectsApiFormDefinitionService
 import org.springframework.graphql.data.method.annotation.Argument
 import org.springframework.graphql.data.method.annotation.QueryMapping
 import org.springframework.stereotype.Controller
@@ -25,50 +24,13 @@ import org.springframework.stereotype.Controller
 @Controller
 class FormDefinitionQuery(
     private val formIoFormDefinitionService: FormIoFormDefinitionService,
-    private val objectenApiFormDefinitionService: ObjectsApiFormDefinitionService,
 ) {
     @QueryMapping
     fun getFormDefinitionByName(
         @Argument name: String,
+        authentication: CommonGroundAuthentication,
     ): FormDefinition? {
         val formIoFormDefinition = formIoFormDefinitionService.findFormIoFormDefinitionByName(name) ?: return null
         return FormDefinition(formIoFormDefinition.formDefinition)
-    }
-
-    @QueryMapping
-    suspend fun getFormDefinitionByObjectenApiUrl(
-        @Argument url: String,
-    ): FormDefinition? {
-        val objectenApiFormDefinition = objectenApiFormDefinitionService.findObjectsApiFormDefinitionByUrl(url) ?: return null
-        return FormDefinition(objectenApiFormDefinition.formDefinition)
-    }
-
-    @Deprecated(
-        message = "Replaced by getFormDefinitionByName and getFormDefinitionByObjectenApiUrl",
-        replaceWith = ReplaceWith("getFormDefinitionByName or getFormDefinitionByObjectenApiUrl"),
-    )
-    @QueryMapping
-    suspend fun getFormDefinitionById(
-        @Argument id: String,
-    ): FormDefinition? {
-        // for backwards compatibility
-        // if the requested id is a UUID, we assume it's an Objecten API id
-        // when the nl-portal-frontend-libraries has been migrated, this method will be removed
-        if (requestedIdIsUuid(id)) {
-            val formIoFormDefinition = objectenApiFormDefinitionService.findObjectsApiFormDefinitionById(id) ?: return null
-            return FormDefinition(formIoFormDefinition.formDefinition)
-        } else {
-            val formIoFormDefinition = formIoFormDefinitionService.findFormIoFormDefinitionByName(id) ?: return null
-            return FormDefinition(formIoFormDefinition.formDefinition)
-        }
-    }
-
-    private fun requestedIdIsUuid(id: String): Boolean {
-        try {
-            fromString(id)
-            return true
-        } catch (e: IllegalArgumentException) {
-            return false
-        }
     }
 }

--- a/form/src/main/kotlin/nl/nlportal/form/service/ObjectsApiFormDefinitionService.kt
+++ b/form/src/main/kotlin/nl/nlportal/form/service/ObjectsApiFormDefinitionService.kt
@@ -15,15 +15,34 @@
  */
 package nl.nlportal.form.service
 
+import nl.nlportal.form.autoconfigure.FormConfig
 import nl.nlportal.form.domain.ObjectsApiFormIoFormDefinition
+import nl.nlportal.form.graphql.FormDefinition
 import nl.nlportal.zgw.objectenapi.service.ObjectenApiService
-import org.springframework.transaction.annotation.Transactional
+import org.slf4j.LoggerFactory
+import java.util.UUID
 
-@Transactional
 class ObjectsApiFormDefinitionService(
     private val objectenApiService: ObjectenApiService,
+    private val formConfig: FormConfig,
 ) {
-    suspend fun findObjectsApiFormDefinitionById(objectId: String): ObjectsApiFormIoFormDefinition? = objectenApiService.getObjectById<ObjectsApiFormIoFormDefinition>(objectId)?.record?.data
+    private val logger = LoggerFactory.getLogger(javaClass)
 
-    suspend fun findObjectsApiFormDefinitionByUrl(objectUrl: String): ObjectsApiFormIoFormDefinition? = objectenApiService.getObjectByUrl<ObjectsApiFormIoFormDefinition>(objectUrl)?.record?.data
+    suspend fun getObjectsApiFormDefinitionById(objectId: UUID): FormDefinition? {
+        val obj =
+            objectenApiService.getObjectById<ObjectsApiFormIoFormDefinition>(objectId.toString())
+                ?: return null
+
+        val expected = formConfig.properties.formDefinitionObjectTypeUrl
+        if (expected == null) {
+            logger.debug("formDefinitionObjectTypeUrl not configured — skipping type validation")
+        } else if (obj.type != expected) {
+            throw RuntimeException(
+                "Object type mismatch for form definition fetch. " +
+                    "Expected: $expected, Actual: ${obj.type}, ObjectId: $objectId",
+            )
+        }
+
+        return FormDefinition(obj.record.data.formDefinition)
+    }
 }

--- a/form/src/main/resources/graphql/schemas.graphqls
+++ b/form/src/main/resources/graphql/schemas.graphqls
@@ -1,24 +1,8 @@
 extend type Query {
-    # find single form definition from repository or Objecten API
-    #deprecated(
-    # reason: "Replaced by getFormDefinitionByName and getFormDefinitionByObjectenApiUrl, replace with getFormDefinitionByName or getFormDefinitionByObjectenApiUrl"
-    #)
-    getFormDefinitionById(
-        # The form definition id
-        id: String!
-    ): FormDefinition
-
-
     # find single form definition from repository
     getFormDefinitionByName(
         # The form definition name
         name: String!
-    ): FormDefinition
-
-    # find single form definition from the Objecten API
-    getFormDefinitionByObjectenApiUrl(
-        # The form definition url
-        url: String!
     ): FormDefinition
 }
 

--- a/form/src/test/resources/graphql/schemas.graphqls
+++ b/form/src/test/resources/graphql/schemas.graphqls
@@ -1,24 +1,8 @@
 type Query {
-    # find single form definition from repository or Objecten API
-    #deprecated(
-    # reason: "Replaced by getFormDefinitionByName and getFormDefinitionByObjectenApiUrl, replace with getFormDefinitionByName or getFormDefinitionByObjectenApiUrl"
-    #)
-    getFormDefinitionById(
-        # The form definition id
-        id: String!
-    ): FormDefinition
-
-
     # find single form definition from repository
     getFormDefinitionByName(
         # The form definition name
         name: String!
-    ): FormDefinition
-
-    # find single form definition from the Objecten API
-    getFormDefinitionByObjectenApiUrl(
-        # The form definition url
-        url: String!
     ): FormDefinition
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,5 +12,5 @@ gradleDockerComposeVersion=0.17.19
 
 org.gradle.jvmargs=-Xmx6g -XX:MaxMetaspaceSize=2048m
 org.gradle.workers.max=10
-version=3.0.3
+version=3.0.4
 

--- a/payment-direct/build.gradle.kts
+++ b/payment-direct/build.gradle.kts
@@ -32,6 +32,7 @@ dependencies {
     api("commons-codec:commons-codec:1.19.0")
     testImplementation(project(":zgw:common-ground-authentication-test"))
     testImplementation(TestDependencies.springBootTest)
+    testImplementation(TestDependencies.h2)
     testImplementation(TestDependencies.assertJCore)
     testImplementation(TestDependencies.mockitoKotlin)
     testImplementation(TestDependencies.kotlinCoroutines)

--- a/payment-direct/src/test/resources/config/application.yml
+++ b/payment-direct/src/test/resources/config/application.yml
@@ -6,6 +6,27 @@ logging:
     level:
         reactor.netty.http.client.HttpClient: TRACE
 
+spring:
+    liquibase:
+        enabled: true
+        change-log: classpath:config/liquibase/form-master.xml
+    datasource:
+        type: com.zaxxer.hikari.HikariDataSource
+        driver-class-name: org.h2.Driver
+        url: jdbc:h2:mem:payment-direct-test;DB_CLOSE_DELAY=-1;MODE=PostgreSQL
+        username: sa
+        password: ""
+        hikari:
+            auto-commit: false
+    jpa:
+        database-platform: org.hibernate.dialect.H2Dialect
+        open-in-view: false
+        properties:
+            hibernate:
+                hbm2ddl.auto: none
+                connection:
+                    provider_disables_autocommit: true
+
 nl-portal:
     config:
         objectenapi:

--- a/payment/build.gradle.kts
+++ b/payment/build.gradle.kts
@@ -30,6 +30,7 @@ dependencies {
 
     testImplementation(project(":zgw:common-ground-authentication-test"))
     testImplementation(TestDependencies.springBootTest)
+    testImplementation(TestDependencies.h2)
     testImplementation(TestDependencies.assertJCore)
     testImplementation(TestDependencies.mockitoKotlin)
     testImplementation(TestDependencies.kotlinCoroutines)

--- a/payment/src/test/resources/config/application.yml
+++ b/payment/src/test/resources/config/application.yml
@@ -2,6 +2,27 @@ graphql:
     packages:
         - "nl.nlportal"
 
+spring:
+    liquibase:
+        enabled: true
+        change-log: classpath:config/liquibase/form-master.xml
+    datasource:
+        type: com.zaxxer.hikari.HikariDataSource
+        driver-class-name: org.h2.Driver
+        url: jdbc:h2:mem:payment-test;DB_CLOSE_DELAY=-1;MODE=PostgreSQL
+        username: sa
+        password: ""
+        hikari:
+            auto-commit: false
+    jpa:
+        database-platform: org.hibernate.dialect.H2Dialect
+        open-in-view: false
+        properties:
+            hibernate:
+                hbm2ddl.auto: none
+                connection:
+                    provider_disables_autocommit: true
+
 nl-portal:
     config:
         objectenapi:

--- a/product/build.gradle.kts
+++ b/product/build.gradle.kts
@@ -32,6 +32,7 @@ dependencies {
 
     testImplementation(project(":zgw:common-ground-authentication-test"))
     testImplementation(TestDependencies.springBootTest)
+    testImplementation(TestDependencies.h2)
     testImplementation(TestDependencies.assertJCore)
     testImplementation(TestDependencies.mockitoKotlin)
     testImplementation(TestDependencies.kotlinCoroutines)

--- a/product/src/test/resources/config/application.yml
+++ b/product/src/test/resources/config/application.yml
@@ -82,6 +82,25 @@ nl-portal:
                 type-url: http://host.docker.internal:8011/api/v1/objecttypes/3e852115-277a-4570-873a-9a64be3aeb37
 
 spring:
+    liquibase:
+        enabled: true
+        change-log: classpath:config/liquibase/form-master.xml
+    datasource:
+        type: com.zaxxer.hikari.HikariDataSource
+        driver-class-name: org.h2.Driver
+        url: jdbc:h2:mem:product-test;DB_CLOSE_DELAY=-1;MODE=PostgreSQL
+        username: sa
+        password: ""
+        hikari:
+            auto-commit: false
+    jpa:
+        database-platform: org.hibernate.dialect.H2Dialect
+        open-in-view: false
+        properties:
+            hibernate:
+                hbm2ddl.auto: none
+                connection:
+                    provider_disables_autocommit: true
     security:
         oauth2:
             resourceserver:

--- a/zgw/openproduct/build.gradle.kts
+++ b/zgw/openproduct/build.gradle.kts
@@ -33,6 +33,7 @@ dependencies {
 
     testImplementation(project(":zgw:common-ground-authentication-test"))
     testImplementation(TestDependencies.postgresql)
+    testImplementation(TestDependencies.h2)
     testImplementation(TestDependencies.springBootTest)
     testImplementation(TestDependencies.springSecurityTest)
     testImplementation(TestDependencies.kotlinCoroutines)

--- a/zgw/openproduct/src/test/resources/config/application.yml
+++ b/zgw/openproduct/src/test/resources/config/application.yml
@@ -62,6 +62,25 @@ logging:
         reactor.netty.http.client.HttpClient: TRACE
 
 spring:
+    liquibase:
+        enabled: true
+        change-log: classpath:config/liquibase/form-master.xml
+    datasource:
+        type: com.zaxxer.hikari.HikariDataSource
+        driver-class-name: org.h2.Driver
+        url: jdbc:h2:mem:openproduct-test;DB_CLOSE_DELAY=-1;MODE=PostgreSQL
+        username: sa
+        password: ""
+        hikari:
+            auto-commit: false
+    jpa:
+        database-platform: org.hibernate.dialect.H2Dialect
+        open-in-view: false
+        properties:
+            hibernate:
+                hbm2ddl.auto: none
+                connection:
+                    provider_disables_autocommit: true
     security:
         oauth2:
             resourceserver:

--- a/zgw/taak/build.gradle.kts
+++ b/zgw/taak/build.gradle.kts
@@ -27,6 +27,7 @@ dependencies {
     api(project(":zgw:common-ground-authentication"))
     api(project(":zgw:objectenapi"))
     api(project(":zgw:documenten-api"))
+    api(project(":form"))
 
 
     implementation(Dependencies.kotlinCoroutines)
@@ -34,6 +35,7 @@ dependencies {
     implementation("org.springframework.data:spring-data-commons")
 
     testImplementation(TestDependencies.springBootTest)
+    testImplementation(TestDependencies.h2)
     testImplementation(project(":zgw:common-ground-authentication-test"))
     testImplementation(TestDependencies.okHttpMockWebserver)
     testImplementation(TestDependencies.mockitoKotlin)

--- a/zgw/taak/src/main/kotlin/nl/nlportal/zgw/taak/autoconfigure/TaakAutoConfiguration.kt
+++ b/zgw/taak/src/main/kotlin/nl/nlportal/zgw/taak/autoconfigure/TaakAutoConfiguration.kt
@@ -20,7 +20,9 @@ import nl.nlportal.core.security.config.HttpSecurityConfigurer
 import nl.nlportal.documentenapi.client.DocumentApisConfig
 import nl.nlportal.documentenapi.service.DocumentenApiService
 import nl.nlportal.documentenapi.service.VirusScanService
+import nl.nlportal.form.service.ObjectsApiFormDefinitionService
 import nl.nlportal.zgw.objectenapi.client.ObjectsApiClient
+import nl.nlportal.zgw.taak.graphql.TaakFormQuery
 import nl.nlportal.zgw.taak.graphql.TaakMutationV2
 import nl.nlportal.zgw.taak.graphql.TaakQueryV2
 import nl.nlportal.zgw.taak.security.config.TaakDocumentResourceHttpSecurityConfigurer
@@ -56,6 +58,15 @@ class TaakAutoConfiguration {
     @ConditionalOnMissingBean(TaakMutationV2::class)
     fun taskMutationV2(taskService: TaakService): TaakMutationV2 {
         return TaakMutationV2(taskService)
+    }
+
+    @Bean
+    @ConditionalOnMissingBean(TaakFormQuery::class)
+    fun taakFormQuery(
+        taskService: TaakService,
+        objectsApiFormDefinitionService: ObjectsApiFormDefinitionService,
+    ): TaakFormQuery {
+        return TaakFormQuery(taskService, objectsApiFormDefinitionService)
     }
 
     @Bean

--- a/zgw/taak/src/main/kotlin/nl/nlportal/zgw/taak/graphql/TaakFormQuery.kt
+++ b/zgw/taak/src/main/kotlin/nl/nlportal/zgw/taak/graphql/TaakFormQuery.kt
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2015-2025 Ritense BV, the Netherlands.
+ *
+ * Licensed under EUPL, Version 1.2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.nlportal.zgw.taak.graphql
+
+import nl.nlportal.commonground.authentication.CommonGroundAuthentication
+import nl.nlportal.form.graphql.FormDefinition
+import nl.nlportal.form.service.ObjectsApiFormDefinitionService
+import nl.nlportal.zgw.taak.domain.TaakFormulierV2
+import nl.nlportal.zgw.taak.service.TaakService
+import org.slf4j.LoggerFactory
+import org.springframework.graphql.data.method.annotation.Argument
+import org.springframework.graphql.data.method.annotation.QueryMapping
+import org.springframework.http.HttpStatus
+import org.springframework.stereotype.Controller
+import org.springframework.web.server.ResponseStatusException
+import java.util.UUID
+
+@Controller
+class TaakFormQuery(
+    private val taakService: TaakService,
+    private val objectsApiFormDefinitionService: ObjectsApiFormDefinitionService,
+) {
+    private val logger = LoggerFactory.getLogger(javaClass)
+
+    @QueryMapping
+    suspend fun getFormDefinitionByTaskId(
+        @Argument taskId: UUID,
+        authentication: CommonGroundAuthentication,
+    ): FormDefinition? {
+        val task = taakService.getTaakByIdV2(taskId, authentication)
+
+        val formulier = task.portaalformulier?.formulier ?: return null
+        val formDefUuid = extractUuid(formulier) ?: return null
+
+        return try {
+            objectsApiFormDefinitionService.getObjectsApiFormDefinitionById(formDefUuid)
+        } catch (ex: RuntimeException) {
+            logger.warn("Security: failed to fetch form definition for task {}: {}", taskId, ex.message)
+            throw ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "Could not retrieve form definition")
+        }
+    }
+
+    private fun extractUuid(formulier: TaakFormulierV2): UUID? =
+        when (formulier.soort) {
+            "id" -> runCatching { UUID.fromString(formulier.value) }.getOrNull()
+            "url" ->
+                Regex("/objects/([0-9a-fA-F-]{36})/?$")
+                    .find(formulier.value)
+                    ?.groupValues
+                    ?.get(1)
+                    ?.let { runCatching { UUID.fromString(it) }.getOrNull() }
+            else -> {
+                logger.warn("Unknown formulier.soort: {}", formulier.soort)
+                null
+            }
+        }
+}

--- a/zgw/taak/src/main/resources/graphql/schema.graphqls
+++ b/zgw/taak/src/main/resources/graphql/schema.graphqls
@@ -10,6 +10,9 @@ extend type Query {
         status: TaakStatus
         title: String
     ): TaakPageV2!
+
+    # Get the form definition for a task the authenticated user owns
+    getFormDefinitionByTaskId(taskId: UUID!): FormDefinition
 }
 
 extend type Mutation {

--- a/zgw/taak/src/test/kotlin/nl/nlportal/zgw/taak/graphql/TaakFormQueryIT.kt
+++ b/zgw/taak/src/test/kotlin/nl/nlportal/zgw/taak/graphql/TaakFormQueryIT.kt
@@ -1,0 +1,155 @@
+/*
+ * Copyright 2015-2025 Ritense BV, the Netherlands.
+ *
+ * Licensed under EUPL, Version 1.2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.nlportal.zgw.taak.graphql
+
+import com.fasterxml.jackson.databind.JsonNode
+import nl.nlportal.commonground.authentication.WithBurgerUser
+import nl.nlportal.zgw.objectenapi.autoconfiguration.ObjectsApiClientConfig
+import nl.nlportal.zgw.taak.TestHelper
+import okhttp3.mockwebserver.Dispatcher
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import okhttp3.mockwebserver.RecordedRequest
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.graphql.tester.AutoConfigureHttpGraphQlTester
+import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.graphql.test.tester.HttpGraphQlTester
+
+@SpringBootTest
+@AutoConfigureHttpGraphQlTester
+@AutoConfigureWebTestClient(timeout = "36000")
+@TestInstance(PER_CLASS)
+@Tag("integration")
+internal class TaakFormQueryIT(
+    @Autowired private val httpGraphQlTester: HttpGraphQlTester,
+    @Autowired private val objectsApiClientConfig: ObjectsApiClientConfig,
+) {
+    lateinit var server: MockWebServer
+
+    @BeforeEach
+    internal fun setUp() {
+        server = MockWebServer()
+        setupMockObjectsApiServer()
+        server.start()
+        objectsApiClientConfig.properties.url = server.url("/").toUri()
+    }
+
+    @AfterEach
+    internal fun tearDown() {
+        server.shutdown()
+    }
+
+    @Test
+    @WithBurgerUser("569312863")
+    fun `returns form definition for task with formulier soort=url`() {
+        val formDefinition = executeForTask("58fad5ab-dc2f-11ec-9075-f22a405ce707")
+
+        assertEquals("form", formDefinition.requiredAt("/formDefinition/display").textValue())
+    }
+
+    @Test
+    @WithBurgerUser("569312863")
+    fun `returns form definition for task with formulier soort=id`() {
+        val formDefinition = executeForTask("44444444-4444-4444-4444-444444444444")
+
+        assertEquals("form", formDefinition.requiredAt("/formDefinition/display").textValue())
+    }
+
+    @Test
+    @WithBurgerUser("569312863")
+    fun `returns null for task without portaalformulier`() {
+        httpGraphQlTester
+            .document(query("33333333-3333-3333-3333-333333333333"))
+            .execute()
+            .errors()
+            .verify()
+            .path("getFormDefinitionByTaskId")
+            .valueIsNull()
+    }
+
+    @Test
+    @WithBurgerUser("000000000")
+    fun `rejects task the user does not own`() {
+        httpGraphQlTester
+            .document(query("58fad5ab-dc2f-11ec-9075-f22a405ce707"))
+            .execute()
+            .errors()
+            .satisfy { errors -> assertFalse(errors.isEmpty()) }
+    }
+
+    @Test
+    @WithBurgerUser("569312863")
+    fun `returns error when fetched object type mismatches configured form definition type`() {
+        httpGraphQlTester
+            .document(query("11111111-1111-1111-1111-111111111111"))
+            .execute()
+            .errors()
+            .satisfy { errors -> assertFalse(errors.isEmpty()) }
+    }
+
+    private fun executeForTask(taskId: String): JsonNode =
+        httpGraphQlTester
+            .document(query(taskId))
+            .execute()
+            .errors()
+            .verify()
+            .path("getFormDefinitionByTaskId")
+            .entity(JsonNode::class.java)
+            .get()
+
+    private fun query(taskId: String): String =
+        """
+        query {
+            getFormDefinitionByTaskId(taskId: "$taskId") {
+                formDefinition
+            }
+        }
+        """.trimIndent()
+
+    private fun setupMockObjectsApiServer() {
+        val dispatcher: Dispatcher =
+            object : Dispatcher() {
+                override fun dispatch(request: RecordedRequest): MockResponse {
+                    val path = request.path?.substringBefore('?')
+                    return when (request.method + " " + path) {
+                        "GET /api/v2/objects/58fad5ab-dc2f-11ec-9075-f22a405ce707" ->
+                            TestHelper.mockResponseFromFile("/data/get-task-form-by-url.json")
+                        "GET /api/v2/objects/44444444-4444-4444-4444-444444444444" ->
+                            TestHelper.mockResponseFromFile("/data/get-task-form-by-id.json")
+                        "GET /api/v2/objects/33333333-3333-3333-3333-333333333333" ->
+                            TestHelper.mockResponseFromFile("/data/get-task-no-form.json")
+                        "GET /api/v2/objects/11111111-1111-1111-1111-111111111111" ->
+                            TestHelper.mockResponseFromFile("/data/get-task-form-mismatch.json")
+                        "GET /api/v2/objects/4e40fb4c-a29a-4e48-944b-c34a1ff6c8f4" ->
+                            TestHelper.mockResponseFromFile("/data/get-form-definition.json")
+                        "GET /api/v2/objects/22222222-2222-2222-2222-222222222222" ->
+                            TestHelper.mockResponseFromFile("/data/get-form-definition-wrong-type.json")
+                        else -> MockResponse().setResponseCode(404)
+                    }
+                }
+            }
+        server.dispatcher = dispatcher
+    }
+}

--- a/zgw/taak/src/test/kotlin/nl/nlportal/zgw/taak/graphql/TaakMutationV2IT.kt
+++ b/zgw/taak/src/test/kotlin/nl/nlportal/zgw/taak/graphql/TaakMutationV2IT.kt
@@ -28,6 +28,7 @@ import okhttp3.mockwebserver.RecordedRequest
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS
@@ -44,6 +45,7 @@ import org.springframework.test.web.reactive.server.WebTestClient
 @AutoConfigureHttpGraphQlTester
 @AutoConfigureWebTestClient(timeout = "36000")
 @TestInstance(PER_CLASS)
+@Tag("integration")
 internal class TaakMutationV2IT(
     @Autowired private val httpGraphQlTester: HttpGraphQlTester,
     @Autowired private val objectsApiClientConfig: ObjectsApiClientConfig,

--- a/zgw/taak/src/test/kotlin/nl/nlportal/zgw/taak/graphql/TaakQueryV2IT.kt
+++ b/zgw/taak/src/test/kotlin/nl/nlportal/zgw/taak/graphql/TaakQueryV2IT.kt
@@ -34,6 +34,7 @@ import okhttp3.mockwebserver.RecordedRequest
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS
@@ -51,6 +52,7 @@ import org.springframework.test.web.reactive.server.WebTestClient
 @AutoConfigureHttpGraphQlTester
 @AutoConfigureWebTestClient(timeout = "36000")
 @TestInstance(PER_CLASS)
+@Tag("integration")
 internal class TaakQueryV2IT(
     @Autowired private val httpGraphQlTester: HttpGraphQlTester,
     @Autowired private val objectsApiClientConfig: ObjectsApiClientConfig,

--- a/zgw/taak/src/test/resources/config/application.yml
+++ b/zgw/taak/src/test/resources/config/application.yml
@@ -13,6 +13,9 @@ nl-portal:
             properties:
                 url: http://localhost:8010
                 token: 0000000000000000000000000000000000000000
+        form:
+            properties:
+                form-definition-object-type-url: "http://localhost:8011/api/v1/objecttypes/form-definition-type"
         taak:
             enabled: true
             properties:
@@ -32,6 +35,25 @@ nl-portal:
             resource-url: classpath:machtigingsdiensten.json
 
 spring:
+    liquibase:
+        enabled: true
+        change-log: classpath:config/liquibase/form-master.xml
+    datasource:
+        type: com.zaxxer.hikari.HikariDataSource
+        driver-class-name: org.h2.Driver
+        url: jdbc:h2:mem:taak-test;DB_CLOSE_DELAY=-1;MODE=PostgreSQL
+        username: sa
+        password: ""
+        hikari:
+            auto-commit: false
+    jpa:
+        database-platform: org.hibernate.dialect.H2Dialect
+        open-in-view: false
+        properties:
+            hibernate:
+                hbm2ddl.auto: none
+                connection:
+                    provider_disables_autocommit: true
     security:
         oauth2:
             resourceserver:

--- a/zgw/taak/src/test/resources/data/get-form-definition-wrong-type.json
+++ b/zgw/taak/src/test/resources/data/get-form-definition-wrong-type.json
@@ -1,0 +1,15 @@
+{
+    "uuid": "22222222-2222-2222-2222-222222222222",
+    "type": "http://localhost:8011/api/v1/objecttypes/some-other-type",
+    "record": {
+        "index": 1,
+        "typeVersion": 1,
+        "data": {
+            "formDefinition": {
+                "display": "form",
+                "components": []
+            }
+        },
+        "startAt": "2022-06-01"
+    }
+}

--- a/zgw/taak/src/test/resources/data/get-form-definition.json
+++ b/zgw/taak/src/test/resources/data/get-form-definition.json
@@ -1,0 +1,21 @@
+{
+    "uuid": "4e40fb4c-a29a-4e48-944b-c34a1ff6c8f4",
+    "type": "http://localhost:8011/api/v1/objecttypes/form-definition-type",
+    "record": {
+        "index": 1,
+        "typeVersion": 1,
+        "data": {
+            "formDefinition": {
+                "display": "form",
+                "components": [
+                    {
+                        "key": "voornaam",
+                        "type": "textfield",
+                        "label": "Voornaam"
+                    }
+                ]
+            }
+        },
+        "startAt": "2022-06-01"
+    }
+}

--- a/zgw/taak/src/test/resources/data/get-task-form-by-id.json
+++ b/zgw/taak/src/test/resources/data/get-task-form-by-id.json
@@ -1,0 +1,32 @@
+{
+    "url": "http://localhost:8010/api/v2/objects/44444444-4444-4444-4444-444444444444",
+    "uuid": "44444444-4444-4444-4444-444444444444",
+    "type": "http://localhost:8011/api/v1/objecttypes/3e852115-277a-4570-873a-9a64be3aeb35",
+    "record": {
+        "index": 1,
+        "typeVersion": 1,
+        "data": {
+            "titel": "Task with id formulier",
+            "status": "open",
+            "soort": "portaalformulier",
+            "verloopdatum": "2023-09-20T18:25:43.524Z",
+            "eigenaar": "gzac",
+            "identificatie": {
+                "type": "bsn",
+                "value": "569312863"
+            },
+            "koppeling": {
+                "registratie": "zaak",
+                "value": "5551a7c5-4e92-43e6-8d23-80359b7e22b7"
+            },
+            "portaalformulier": {
+                "formulier": {
+                    "soort": "id",
+                    "value": "4e40fb4c-a29a-4e48-944b-c34a1ff6c8f4"
+                }
+            },
+            "verwerker_taak_id": "44444444-4444-4444-4444-444444444445"
+        },
+        "startAt": "2022-06-01"
+    }
+}

--- a/zgw/taak/src/test/resources/data/get-task-form-by-url.json
+++ b/zgw/taak/src/test/resources/data/get-task-form-by-url.json
@@ -1,0 +1,32 @@
+{
+    "url": "http://localhost:8010/api/v2/objects/58fad5ab-dc2f-11ec-9075-f22a405ce707",
+    "uuid": "58fad5ab-dc2f-11ec-9075-f22a405ce707",
+    "type": "http://localhost:8011/api/v1/objecttypes/3e852115-277a-4570-873a-9a64be3aeb35",
+    "record": {
+        "index": 1,
+        "typeVersion": 1,
+        "data": {
+            "titel": "Task with url formulier",
+            "status": "open",
+            "soort": "portaalformulier",
+            "verloopdatum": "2023-09-20T18:25:43.524Z",
+            "eigenaar": "gzac",
+            "identificatie": {
+                "type": "bsn",
+                "value": "569312863"
+            },
+            "koppeling": {
+                "registratie": "zaak",
+                "value": "5551a7c5-4e92-43e6-8d23-80359b7e22b7"
+            },
+            "portaalformulier": {
+                "formulier": {
+                    "soort": "url",
+                    "value": "http://localhost:8010/api/v2/objects/4e40fb4c-a29a-4e48-944b-c34a1ff6c8f4"
+                }
+            },
+            "verwerker_taak_id": "58fad5ab-dc2f-11ec-9075-f22a405ce708"
+        },
+        "startAt": "2022-06-01"
+    }
+}

--- a/zgw/taak/src/test/resources/data/get-task-form-mismatch.json
+++ b/zgw/taak/src/test/resources/data/get-task-form-mismatch.json
@@ -1,0 +1,32 @@
+{
+    "url": "http://localhost:8010/api/v2/objects/11111111-1111-1111-1111-111111111111",
+    "uuid": "11111111-1111-1111-1111-111111111111",
+    "type": "http://localhost:8011/api/v1/objecttypes/3e852115-277a-4570-873a-9a64be3aeb35",
+    "record": {
+        "index": 1,
+        "typeVersion": 1,
+        "data": {
+            "titel": "Task pointing to wrong object type",
+            "status": "open",
+            "soort": "portaalformulier",
+            "verloopdatum": "2023-09-20T18:25:43.524Z",
+            "eigenaar": "gzac",
+            "identificatie": {
+                "type": "bsn",
+                "value": "569312863"
+            },
+            "koppeling": {
+                "registratie": "zaak",
+                "value": "5551a7c5-4e92-43e6-8d23-80359b7e22b7"
+            },
+            "portaalformulier": {
+                "formulier": {
+                    "soort": "url",
+                    "value": "http://localhost:8010/api/v2/objects/22222222-2222-2222-2222-222222222222"
+                }
+            },
+            "verwerker_taak_id": "11111111-1111-1111-1111-111111111112"
+        },
+        "startAt": "2022-06-01"
+    }
+}

--- a/zgw/taak/src/test/resources/data/get-task-no-form.json
+++ b/zgw/taak/src/test/resources/data/get-task-no-form.json
@@ -1,0 +1,29 @@
+{
+    "url": "http://localhost:8010/api/v2/objects/33333333-3333-3333-3333-333333333333",
+    "uuid": "33333333-3333-3333-3333-333333333333",
+    "type": "http://localhost:8011/api/v1/objecttypes/3e852115-277a-4570-873a-9a64be3aeb35",
+    "record": {
+        "index": 1,
+        "typeVersion": 1,
+        "data": {
+            "titel": "Task without portaalformulier",
+            "status": "open",
+            "soort": "url",
+            "verloopdatum": null,
+            "eigenaar": "gzac",
+            "identificatie": {
+                "type": "bsn",
+                "value": "569312863"
+            },
+            "koppeling": {
+                "registratie": "zaak",
+                "value": "5551a7c5-4e92-43e6-8d23-80359b7e22b7"
+            },
+            "url": {
+                "uri": "http://example.com/some-task"
+            },
+            "verwerker_taak_id": "33333333-3333-3333-3333-333333333334"
+        },
+        "startAt": "2022-06-01"
+    }
+}

--- a/zgw/taak/src/test/resources/graphql/schema.graphqls
+++ b/zgw/taak/src/test/resources/graphql/schema.graphqls
@@ -10,6 +10,9 @@ type Query {
         status: TaakStatus
         title: String
     ): TaakPageV2!
+
+    # Get the form definition for a task the authenticated user owns
+    getFormDefinitionByTaskId(taskId: UUID!): FormDefinition
 }
 
 type Mutation {
@@ -93,6 +96,10 @@ type OgoneBetaling {
     bedrag: PositiveFloat!
     betaalkenmerk: String!
     pspid: String!
+}
+
+type FormDefinition {
+    formDefinition: JSON!
 }
 
 scalar JSON


### PR DESCRIPTION
* fix same-host SSRF in form definition fetching
* remove getFormDefinitionByObjectenApiUrl and getFormDefinitionById queries
* let consumer modules handle authorization/authentication in their own context