### PR TITLE
feat: refactored besluit documents the same as other document flows (show and download)

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ dockerRegion=eu-central-1
 sonatypeCentralStagingDir=sonatypeCentralStaging
 
 kotlinVersion=2.4.0
-springBootVersion=3.5.15
+springBootVersion=3.5.16
 springDependencyManagementVersion=1.1.7
 benManesVersionsVersion=0.54.0
 spotlessVersion=8.7.0

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/zgw/besluiten/build.gradle.kts
+++ b/zgw/besluiten/build.gradle.kts
@@ -24,7 +24,8 @@ dependencies {
     api(project(":zgw:idtoken-authentication"))
     api(project(":graphql"))
     api(project(":zgw:catalogi-api"))
-    api(Dependencies.springWebFlux)
+    api(project(":zgw:documenten-api"))
+    //api(Dependencies.springWebFlux)
 
     implementation(Dependencies.springBootStarter)
 
@@ -32,8 +33,8 @@ dependencies {
     implementation(Dependencies.kotlinCoroutinesReactor)
     implementation("org.springframework.data:spring-data-commons")
 
-    testImplementation(TestDependencies.kotlinTest)
-    testImplementation(TestDependencies.junitJupiterTest)
+    //testImplementation(TestDependencies.kotlinTest)
+    //testImplementation(TestDependencies.junitJupiterTest)
     testImplementation(TestDependencies.springBootTest)
     testImplementation(TestDependencies.springSecurityTest)
 
@@ -41,9 +42,9 @@ dependencies {
     testImplementation(TestDependencies.mockitoKotlin)
     testImplementation(TestDependencies.okHttpMockWebserver)
     testImplementation(TestDependencies.okHttp)
-    testImplementation(TestDependencies.postgresql)
+    //testImplementation(TestDependencies.postgresql)
     testImplementation(project(":zgw:common-ground-authentication-test"))
-    testImplementation("org.springframework.graphql:spring-graphql-test")
+    //testImplementation("org.springframework.graphql:spring-graphql-test")
 }
 
 val jar: Jar by tasks

--- a/zgw/besluiten/build.gradle.kts
+++ b/zgw/besluiten/build.gradle.kts
@@ -25,7 +25,6 @@ dependencies {
     api(project(":graphql"))
     api(project(":zgw:catalogi-api"))
     api(project(":zgw:documenten-api"))
-    //api(Dependencies.springWebFlux)
 
     implementation(Dependencies.springBootStarter)
 
@@ -33,8 +32,6 @@ dependencies {
     implementation(Dependencies.kotlinCoroutinesReactor)
     implementation("org.springframework.data:spring-data-commons")
 
-    //testImplementation(TestDependencies.kotlinTest)
-    //testImplementation(TestDependencies.junitJupiterTest)
     testImplementation(TestDependencies.springBootTest)
     testImplementation(TestDependencies.springSecurityTest)
 
@@ -42,9 +39,7 @@ dependencies {
     testImplementation(TestDependencies.mockitoKotlin)
     testImplementation(TestDependencies.okHttpMockWebserver)
     testImplementation(TestDependencies.okHttp)
-    //testImplementation(TestDependencies.postgresql)
     testImplementation(project(":zgw:common-ground-authentication-test"))
-    //testImplementation("org.springframework.graphql:spring-graphql-test")
 }
 
 val jar: Jar by tasks

--- a/zgw/besluiten/src/main/kotlin/nl/nlportal/besluiten/autoconfigure/BesluitenAutoConfiguration.kt
+++ b/zgw/besluiten/src/main/kotlin/nl/nlportal/besluiten/autoconfigure/BesluitenAutoConfiguration.kt
@@ -2,8 +2,15 @@ package nl.nlportal.besluiten.autoconfigure
 
 import nl.nlportal.besluiten.client.BesluitenApiClient
 import nl.nlportal.besluiten.client.BesluitenApiConfig
+import nl.nlportal.besluiten.graphql.BesluitenQuery
+import nl.nlportal.besluiten.security.config.BesluitDocumentResourceHttpSecurityConfigurer
 import nl.nlportal.besluiten.service.BesluitenService
+import nl.nlportal.besluiten.web.rest.BesluitDocumentResource
+import nl.nlportal.catalogiapi.service.CatalogiApiService
+import nl.nlportal.core.security.config.HttpSecurityConfigurer
+import nl.nlportal.documentenapi.service.DocumentenApiService
 import org.springframework.boot.autoconfigure.AutoConfiguration
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean
@@ -11,9 +18,10 @@ import org.springframework.web.reactive.function.client.WebClient
 
 @AutoConfiguration
 @EnableConfigurationProperties(BesluitenApiConfig::class)
-@ConditionalOnProperty(prefix = "nl-portal.config.besluitenapi", name = ["enabled"], havingValue = "true")
+@ConditionalOnProperty(prefix = "nl-portal.config", name = ["besluitenapi.enabled", "documentenapis.enabled"], havingValue = "true")
 class BesluitenAutoConfiguration {
     @Bean
+    @ConditionalOnMissingBean(BesluitenApiClient::class)
     fun besluitenApiClient(
         besluitenApiConfig: BesluitenApiConfig,
         webClientBuilder: WebClient.Builder,
@@ -22,7 +30,34 @@ class BesluitenAutoConfiguration {
     }
 
     @Bean
-    fun besluitenService(besluitenApiClient: BesluitenApiClient): BesluitenService {
-        return BesluitenService(besluitenApiClient)
+    @ConditionalOnMissingBean(BesluitenService::class)
+    fun besluitenService(
+        besluitenApiClient: BesluitenApiClient,
+        documentenApiService: DocumentenApiService,
+    ): BesluitenService {
+        return BesluitenService(
+            besluitenApiClient = besluitenApiClient,
+            documentenApiService = documentenApiService
+        )
     }
+
+    @Bean
+    @ConditionalOnMissingBean(BesluitenQuery::class)
+    fun besluitenQuery(
+        besluitenService: BesluitenService,
+        catalogiApiService: CatalogiApiService
+    ): BesluitenQuery = BesluitenQuery(
+        besluitenService = besluitenService,
+        catalogiApiService = catalogiApiService
+    )
+
+    @Bean
+    @ConditionalOnMissingBean(BesluitDocumentResource::class)
+    fun besluitDocumentResource(
+        besluitenService: BesluitenService,
+    ): BesluitDocumentResource = BesluitDocumentResource(besluitenService)
+
+    @Bean
+    @ConditionalOnMissingBean(BesluitDocumentResourceHttpSecurityConfigurer::class)
+    fun besluitDocumentResourceHttpSecurityConfigurer(): HttpSecurityConfigurer = BesluitDocumentResourceHttpSecurityConfigurer()
 }

--- a/zgw/besluiten/src/main/kotlin/nl/nlportal/besluiten/client/BesluitenApiClient.kt
+++ b/zgw/besluiten/src/main/kotlin/nl/nlportal/besluiten/client/BesluitenApiClient.kt
@@ -96,11 +96,11 @@ class BesluitenApiClient(
     }
 
     suspend fun getBesluitDocumenten(
-        besluit: String?,
+        besluit: String,
         informatieobject: String?,
     ): List<BesluitDocument> {
         val params = LinkedMultiValueMap<String, String>()
-        besluit?.let { params.add("besluit", it) }
+        params.add("besluit", besluit)
         informatieobject?.let { params.add("informatieobject", it) }
         return webClient
             .get()

--- a/zgw/besluiten/src/main/kotlin/nl/nlportal/besluiten/graphql/BesluitenQuery.kt
+++ b/zgw/besluiten/src/main/kotlin/nl/nlportal/besluiten/graphql/BesluitenQuery.kt
@@ -6,7 +6,9 @@ import nl.nlportal.besluiten.domain.BesluitDocument
 import nl.nlportal.besluiten.service.BesluitenService
 import nl.nlportal.catalogiapi.domain.BesluitType
 import nl.nlportal.catalogiapi.service.CatalogiApiService
+import nl.nlportal.commonground.authentication.CommonGroundAuthentication
 import nl.nlportal.core.util.CoreUtils
+import nl.nlportal.documentenapi.domain.Document
 import org.springframework.graphql.data.method.annotation.SchemaMapping
 import org.springframework.stereotype.Controller
 
@@ -24,9 +26,13 @@ class BesluitenQuery(
 
     @SchemaMapping(typeName = "Besluit", field = "documenten")
     suspend fun documenten(
+        authentication: CommonGroundAuthentication,
         besluit: Besluit
-    ): List<BesluitDocument> {
-        return besluitenService.getBesluitDocumenten(besluit.url)
+    ): List<Document> {
+        return besluitenService.getBesluitDocumenten(
+            authentication = authentication,
+            besluit = besluit.url
+        )
     }
 
     @SchemaMapping(typeName = "Besluit", field = "besluittype")

--- a/zgw/besluiten/src/main/kotlin/nl/nlportal/besluiten/security/config/BesluitDocumentResourceHttpSecurityConfigurer.kt
+++ b/zgw/besluiten/src/main/kotlin/nl/nlportal/besluiten/security/config/BesluitDocumentResourceHttpSecurityConfigurer.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2026 Ritense BV, the Netherlands.
+ *
+ * Licensed under EUPL, Version 1.2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.nlportal.besluiten.security.config
+
+import nl.nlportal.core.security.config.HttpSecurityConfigurer
+import org.springframework.context.annotation.Configuration
+import org.springframework.http.HttpMethod.GET
+import org.springframework.security.config.web.server.ServerHttpSecurity
+
+@Configuration
+class BesluitDocumentResourceHttpSecurityConfigurer : HttpSecurityConfigurer {
+    override fun configure(http: ServerHttpSecurity) {
+        http.authorizeExchange { authorize ->
+            authorize.pathMatchers(GET, "/api/besluiten/{besluitId}/document/{documentId}/content").authenticated()
+        }
+    }
+}

--- a/zgw/besluiten/src/main/kotlin/nl/nlportal/besluiten/service/BesluitenService.kt
+++ b/zgw/besluiten/src/main/kotlin/nl/nlportal/besluiten/service/BesluitenService.kt
@@ -5,9 +5,18 @@ import nl.nlportal.besluiten.domain.Besluit
 import nl.nlportal.besluiten.domain.BesluitAuditTrail
 import nl.nlportal.besluiten.domain.BesluitDocument
 import java.util.UUID
+import kotlinx.coroutines.flow.Flow
+import nl.nlportal.commonground.authentication.CommonGroundAuthentication
+import nl.nlportal.core.util.CoreUtils.extractId
+import nl.nlportal.documentenapi.domain.Document
+import nl.nlportal.documentenapi.service.DocumentenApiService
+import org.springframework.core.io.buffer.DataBuffer
+import org.springframework.http.HttpStatus
+import org.springframework.web.server.ResponseStatusException
 
 class BesluitenService(
-    val besluitenApiClient: BesluitenApiClient,
+    private val besluitenApiClient: BesluitenApiClient,
+    private val documentenApiService: DocumentenApiService,
 ) {
     suspend fun getBesluiten(
         besluitType: String? = null,
@@ -16,35 +25,56 @@ class BesluitenService(
         verantwoordelijkeOrganisatie: String? = null,
         zaak: String? = null,
     ): List<Besluit> {
-        return besluitenApiClient.getBesluiten(
+
+        val besluiten = besluitenApiClient.getBesluiten(
             besluitType = besluitType,
             identificatie = identificatie,
             page = page,
             verantwoordelijkeOrganisatie = verantwoordelijkeOrganisatie,
             zaak = zaak,
         )
-    }
 
-    suspend fun getBesluit(besluitId: UUID): Besluit {
-        return besluitenApiClient.getBesluit(besluitId)
+        return besluiten
     }
 
     suspend fun getBesluitAuditTrails(besluitId: UUID): List<BesluitAuditTrail> {
         return besluitenApiClient.getBesluitAuditTrails(besluitId).sortedBy { it.aanmaakdatum }
     }
 
-    suspend fun getBesluitAuditTrail(
-        besluitId: UUID,
-        auditTrailId: UUID,
-    ): BesluitAuditTrail {
-        return besluitenApiClient.getBesluitAuditTrail(besluitId, auditTrailId)
+    suspend fun getBesluitDocumenten(
+        authentication: CommonGroundAuthentication,
+        besluit: String,
+        informatieobject: String? = null,
+    ): List<Document> {
+        val besluitDocuments = besluitenApiClient.getBesluitDocumenten(
+            besluit = besluit,
+            informatieobject = informatieobject
+        )
+        return documentenApiService.filterDocuments(
+            besluitDocuments.map {
+                documentenApiService
+                    .getDocument(it.informatieobject)
+                    .copy(identificatie = authentication.userId)
+            },
+        )
     }
 
-    suspend fun getBesluitDocumenten(
-        besluit: String? = null,
-        informatieobject: String? = null,
-    ): List<BesluitDocument> {
-        return besluitenApiClient.getBesluitDocumenten(besluit, informatieobject)
+    suspend fun getBerichtDocumentContent(
+        authentication: CommonGroundAuthentication,
+        besluitId: UUID,
+        documentId: UUID,
+    ): Pair<Document, Flow<DataBuffer>>? {
+        val besluit = besluitenApiClient.getBesluit(
+            besluitId = besluitId,
+        )
+        val besluitDocument = besluitenApiClient.getBesluitDocument(documentId)
+        if(besluitDocument.besluit != besluit.url) {
+            throw ResponseStatusException(HttpStatus.BAD_REQUEST, "Besluit document is not related to besluit")
+        }
+
+        val document = documentenApiService.getDocument(besluitDocument.url)
+        val content = documentenApiService.getDocumentContentStreaming(besluitDocument.url)
+        return document to content
     }
 
     suspend fun getBesluitDocument(documentId: UUID): BesluitDocument {

--- a/zgw/besluiten/src/main/kotlin/nl/nlportal/besluiten/service/BesluitenService.kt
+++ b/zgw/besluiten/src/main/kotlin/nl/nlportal/besluiten/service/BesluitenService.kt
@@ -59,11 +59,10 @@ class BesluitenService(
         )
     }
 
-    suspend fun getBerichtDocumentContent(
-        authentication: CommonGroundAuthentication,
+    suspend fun getBesluitDocumentContent(
         besluitId: UUID,
         documentId: UUID,
-    ): Pair<Document, Flow<DataBuffer>>? {
+    ): Pair<Document, Flow<DataBuffer>> {
         val besluit = besluitenApiClient.getBesluit(
             besluitId = besluitId,
         )

--- a/zgw/besluiten/src/main/kotlin/nl/nlportal/besluiten/web/rest/BesluitDocumentResource.kt
+++ b/zgw/besluiten/src/main/kotlin/nl/nlportal/besluiten/web/rest/BesluitDocumentResource.kt
@@ -43,8 +43,7 @@ class BesluitDocumentResource(
         authentication: CommonGroundAuthentication,
     ): ResponseEntity<Flow<DataBuffer>> {
         val (document, content) =
-            besluitenService.getBerichtDocumentContent(
-                authentication= authentication,
+            besluitenService.getBesluitDocumentContent(
                 besluitId = besluitId,
                 documentId = documentId
             )

--- a/zgw/besluiten/src/main/kotlin/nl/nlportal/besluiten/web/rest/BesluitDocumentResource.kt
+++ b/zgw/besluiten/src/main/kotlin/nl/nlportal/besluiten/web/rest/BesluitDocumentResource.kt
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2026 Ritense BV, the Netherlands.
+ *
+ * Licensed under EUPL, Version 1.2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.nlportal.besluiten.web.rest
+
+import java.util.UUID
+import kotlinx.coroutines.flow.Flow
+import nl.nlportal.besluiten.service.BesluitenService
+import nl.nlportal.commonground.authentication.CommonGroundAuthentication
+import nl.nlportal.documentenapi.util.FilenameSanitizer
+import org.springframework.core.io.buffer.DataBuffer
+import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.server.ResponseStatusException
+
+@RestController
+@RequestMapping(value = ["/api/besluiten"])
+class BesluitDocumentResource(
+    private val besluitenService: BesluitenService,
+) {
+    @GetMapping(value = ["/{besluitId}/document/{documentId}/content"])
+    suspend fun downloadStreaming(
+        @PathVariable besluitId: UUID,
+        @PathVariable documentId: UUID,
+        authentication: CommonGroundAuthentication,
+    ): ResponseEntity<Flow<DataBuffer>> {
+        val (document, content) =
+            besluitenService.getBerichtDocumentContent(
+                authentication= authentication,
+                besluitId = besluitId,
+                documentId = documentId
+            )
+                ?: throw ResponseStatusException(HttpStatus.NOT_FOUND, "Besluit not found")
+
+        return ResponseEntity
+            .ok()
+            .headers(
+                HttpHeaders().apply {
+                    set(
+                        "Content-Disposition",
+                        FilenameSanitizer.encodeForContentDisposition(document.bestandsnaam),
+                    )
+                },
+            ).contentType(MediaType.APPLICATION_OCTET_STREAM)
+            .body(content)
+    }
+}

--- a/zgw/besluiten/src/main/resources/graphql/schema.graphqls
+++ b/zgw/besluiten/src/main/resources/graphql/schema.graphqls
@@ -15,7 +15,7 @@ type Besluit {
     zaak: String!
     auditTrails: [BesluitAuditTrail!]!
     besluittype: BesluitType!
-    documenten: [BesluitDocument!]!
+    documenten: [Document!]!
 }
 
 type BesluitAuditTrail {

--- a/zgw/besluiten/src/test/kotlin/nl/nlportal/besluiten/TestApplication.kt
+++ b/zgw/besluiten/src/test/kotlin/nl/nlportal/besluiten/TestApplication.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2024 Ritense BV, the Netherlands.
+ *
+ * Licensed under EUPL, Version 1.2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.nlportal.besluiten
+
+import nl.nlportal.core.security.OauthSecurityAutoConfiguration
+import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.runApplication
+import org.springframework.context.annotation.Bean
+import org.springframework.security.config.web.server.ServerHttpSecurity
+import org.springframework.security.web.server.SecurityWebFilterChain
+
+@SpringBootApplication(
+    exclude = [
+        OauthSecurityAutoConfiguration::class,
+    ],
+)
+class TestApplication {
+    fun main(args: Array<String>) {
+        runApplication<TestApplication>(*args)
+    }
+
+    @Bean
+    fun springSecurityWebFilterChain(http: ServerHttpSecurity): SecurityWebFilterChain =
+        http
+            .csrf { it.disable() }
+            .authorizeExchange {
+                it.anyExchange().permitAll()
+            }.build()
+}

--- a/zgw/besluiten/src/test/kotlin/nl/nlportal/besluiten/TestHelper.kt
+++ b/zgw/besluiten/src/test/kotlin/nl/nlportal/besluiten/TestHelper.kt
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) 2024 Ritense BV, the Netherlands.
+ *
+ * Licensed under EUPL, Version 1.2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.nlportal.besluiten
+
+import io.github.oshai.kotlinlogging.KotlinLogging
+import okhttp3.mockwebserver.MockResponse
+import org.springframework.test.web.reactive.server.WebTestClient
+import java.util.function.Consumer
+
+object TestHelper {
+    val ERRORS_JSON_PATH = "$.errors"
+    val EXTENSIONS_JSON_PATH = "$.extensions"
+    private val logger = KotlinLogging.logger {}
+
+    fun WebTestClient.ResponseSpec.verifyOnlyDataExists(basePath: String): WebTestClient.BodyContentSpec =
+        this
+            .expectBody()
+            .consumeWith(Consumer { t -> logger.info { t } })
+            .jsonPath(basePath)
+            .exists()
+            .jsonPath(ERRORS_JSON_PATH)
+            .doesNotExist()
+            .jsonPath(EXTENSIONS_JSON_PATH)
+            .doesNotExist()
+
+    fun mockResponse(body: String): MockResponse =
+        MockResponse()
+            .addHeader("Content-Type", "application/json; charset=utf-8")
+            .setResponseCode(200)
+            .setBody(body)
+
+    val handleBesluitRequest =
+        """
+        {
+          "url": "http://localhost:8001/besluiten/api/v1/besluiten/8863ab83-3496-4f40-9cad-f9d9526597c8",
+          "identificatie": "klantportaal",
+          "verantwoordelijkeOrganisatie": "klantportaal",
+          "besluittype": "http://localhost:8000/catalogi/api/v1/besluittypen/496f51fd-ccdb-406e-805a-e7602ae78a2b",
+          "zaak": "http://localhost:8001/zaken/api/v1/zaken/496f51fd-ccdb-406e-805a-e7602ae78a2x",
+          "datum": "2019-08-24",
+          "toelichting": "toelichting",
+          "bestuursorgaan": "klant",
+          "ingangsdatum": "2019-08-24",
+          "vervaldatum": "2019-08-24",
+          "vervalreden": "tijdelijk",
+          "vervalredenWeergave": "string",
+          "publicatiedatum": "2019-08-24",
+          "verzenddatum": "2019-08-24",
+          "uiterlijkeReactiedatum": "2019-08-24"
+        }
+        """.trimIndent()
+
+    val handleBesluitDocumentRequest =
+        """
+          {
+            "url": "http://localhost:10001/enkelvoudiginformatieobjecten/095be615-a8ad-4c33-8e9c-c7612fbf6c9f",
+            "informatieobject": "http://localhost:10001/enkelvoudiginformatieobjecten/095be615-a8ad-4c33-8e9c-c7612fbf6c9f",
+            "besluit": "http://localhost:8001/besluiten/api/v1/besluiten/8863ab83-3496-4f40-9cad-f9d9526597c8"
+          }    
+        """.trimIndent()
+
+    val handleBesluitDocumentUnrelatedRequest =
+        """
+          {
+            "url": "http://localhost:10001/enkelvoudiginformatieobjecten/00000000-0000-0000-0000-0000000000ff",
+            "informatieobject": "http://localhost:10001/enkelvoudiginformatieobjecten/00000000-0000-0000-0000-0000000000ff",
+            "besluit": "http://localhost:8001/besluiten/api/v1/besluiten/2a27bc3c-6a4c-432a-a9cb-5c31004e7769"
+          }    
+        """.trimIndent()
+
+    val handleDocumentResponse =
+        """
+        {
+           "url": "http://some.domain.com/enkelvoudiginformatieobjecten/095be615-a8ad-4c33-8e9c-c7612fbf6c9f",
+           "identificatie": "string",
+           "bronorganisatie": "string",
+           "creatiedatum": "2021-10-14",
+           "titel": "Een titel",
+           "vertrouwelijkheidaanduiding": "openbaar",
+           "auteur": "string",
+           "status": "definitief",
+           "formaat": ".pdf",
+           "taal": "str",
+           "versie": 0,
+           "beginRegistratie": "2021-10-14T12:27:43Z",
+           "bestandsnaam": "string",
+           "inhoud": "http://example.com",
+           "bestandsomvang": 0,
+           "link": "http://example.com",
+           "beschrijving": "string",
+           "ontvangstdatum": "2021-10-14",
+           "verzenddatum": "2021-10-14",
+           "indicatieGebruiksrecht": true,
+           "ondertekening": {
+             "soort": "analoog",
+             "datum": "2021-10-14"
+           },
+           "integriteit": {
+             "algoritme": "crc_16",
+             "waarde": "string",
+             "datum": "2021-10-14"
+           },
+           "informatieobjecttype": "http://example.com",
+           "locked": true,
+           "bestandsdelen": [
+             {
+               "url": "http://example.com",
+               "volgnummer": 0,
+               "omvang": 0,
+               "inhoud": "http://example.com",
+               "voltooid": true,
+               "lock": "string"
+             }
+           ]
+         }
+        """.trimIndent()
+}

--- a/zgw/besluiten/src/test/kotlin/nl/nlportal/besluiten/web/rest/BesluitDocumentResourceIT.kt
+++ b/zgw/besluiten/src/test/kotlin/nl/nlportal/besluiten/web/rest/BesluitDocumentResourceIT.kt
@@ -1,0 +1,165 @@
+/*
+ * Copyright (c) 2026 Ritense BV, the Netherlands.
+ *
+ * Licensed under EUPL, Version 1.2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.nlportal.besluiten.web.rest
+
+import io.github.oshai.kotlinlogging.KotlinLogging
+import nl.nlportal.besluiten.TestHelper
+import nl.nlportal.besluiten.client.BesluitenApiConfig
+import nl.nlportal.commonground.authentication.WithBurgerUser
+import nl.nlportal.documentenapi.client.DocumentApisConfig
+import okhttp3.mockwebserver.Dispatcher
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import okhttp3.mockwebserver.RecordedRequest
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.TestInstance.Lifecycle
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.DynamicPropertyRegistry
+import org.springframework.test.context.DynamicPropertySource
+import org.springframework.test.web.reactive.server.WebTestClient
+
+@SpringBootTest
+@AutoConfigureWebTestClient(timeout = "36000")
+@TestInstance(Lifecycle.PER_METHOD)
+class BesluitDocumentResourceIT(
+    @Autowired private val webTestClient: WebTestClient,
+    @Autowired private val documentApisConfig: DocumentApisConfig,
+    @Autowired private val besluitenApiConfig: BesluitenApiConfig
+) {
+    companion object {
+        private const val KNOWN_DOC_ID = "095be615-a8ad-4c33-8e9c-c7612fbf6c9f"
+        private const val BESLUIT_ID = "8863ab83-3496-4f40-9cad-f9d9526597c8"
+        private const val UNKNOWN_BESLUIT_ID = "2a27bc3c-6a4c-432a-a9cb-5c31004e7769"
+        private const val UNRELATED_DOC_ID = "00000000-0000-0000-0000-0000000000ff"
+        private val logger = KotlinLogging.logger {}
+
+        @JvmStatic
+        var server: MockWebServer? = null
+
+        @JvmStatic
+        var url: String = ""
+
+        @JvmStatic
+        @DynamicPropertySource
+        fun properties(propsRegistry: DynamicPropertyRegistry) {
+            propsRegistry.add("nl-portal.config.besluitenapi.properties.url") { url }
+        }
+
+        @JvmStatic
+        @BeforeAll
+        fun beforeAll() {
+            server = MockWebServer()
+            server?.start(10001)
+            url = server?.url("/").toString()
+        }
+
+        @JvmStatic
+        @AfterAll
+        fun afterAll() {
+            server?.shutdown()
+        }
+    }
+
+    @BeforeEach
+    internal fun setUp() {
+        setupDispatcher()
+        url = server?.url("/").toString()
+        besluitenApiConfig.properties.url = url
+        documentApisConfig.properties.getConfig("openzaak").url = server?.url("/").toString()
+    }
+
+    @Test
+    @WithBurgerUser("999990755")
+    fun `should stream content with safe Content-Disposition header for valid request`() {
+        webTestClient
+            .get()
+            .uri("/api/besluiten/$BESLUIT_ID/document/$KNOWN_DOC_ID/content")
+            .exchange()
+            .expectStatus()
+            .isOk
+            .expectHeader()
+            .exists("Content-Disposition")
+            .expectHeader()
+            .valueMatches("Content-Disposition", "attachment; filename=\".*\"")
+    }
+
+    @Test
+    @WithBurgerUser("999990755")
+    fun `should return 404 when besluit not found`() {
+        webTestClient
+            .get()
+            .uri("/api/besluiten/$UNKNOWN_BESLUIT_ID/document/$KNOWN_DOC_ID/content")
+            .exchange()
+            .expectStatus()
+            .isNotFound
+    }
+
+    @Test
+    @WithBurgerUser("999990755")
+    fun `should return 400 when besluit document is not related to besluit`() {
+        webTestClient
+            .get()
+            .uri("/api/besluiten/$BESLUIT_ID/document/$UNRELATED_DOC_ID/content")
+            .exchange()
+            .expectStatus()
+            .isBadRequest
+    }
+
+    private fun setupDispatcher() {
+        val dispatcher: Dispatcher =
+            object : Dispatcher() {
+                @Throws(InterruptedException::class)
+                override fun dispatch(request: RecordedRequest): MockResponse {
+                    val path = request.path?.substringBefore('?')
+                    return when (request.method + " " + path) {
+                        "GET /besluiten/api/v1/besluiten/$BESLUIT_ID" -> {
+                            TestHelper.mockResponse(TestHelper.handleBesluitRequest)
+                        }
+
+                        "GET /besluiten/api/v1/besluitinformatieobjecten/$KNOWN_DOC_ID" -> {
+                            TestHelper.mockResponse(TestHelper.handleBesluitDocumentRequest)
+                        }
+
+                        "GET /besluiten/api/v1/besluitinformatieobjecten/$UNRELATED_DOC_ID" -> {
+                            TestHelper.mockResponse(TestHelper.handleBesluitDocumentUnrelatedRequest)
+                        }
+
+                        "GET /enkelvoudiginformatieobjecten/$KNOWN_DOC_ID" -> {
+                            TestHelper.mockResponse(TestHelper.handleDocumentResponse)
+                        }
+
+                        "GET /enkelvoudiginformatieobjecten/$KNOWN_DOC_ID/download" -> {
+                            MockResponse()
+                                .setResponseCode(200)
+                                .setHeader("Content-Type", "application/octet-stream")
+                                .setBody("file-bytes")
+                        }
+
+                        else -> {
+                            MockResponse().setResponseCode(404)
+                        }
+                    }
+                }
+            }
+        server?.dispatcher = dispatcher
+    }
+}

--- a/zgw/besluiten/src/test/resources/config/application.yml
+++ b/zgw/besluiten/src/test/resources/config/application.yml
@@ -2,6 +2,7 @@ graphql:
     packages:
         - "nl.nlportal"
 
+
 spring:
     security:
         oauth2:
@@ -22,6 +23,21 @@ nl-portal:
                 url: http://localhost:8001
                 clientId: valtimo_client
                 secret: e09b8bc5-5831-4618-ab28-41411304309d
+        documentenapis:
+            enabled: true
+            properties:
+                default-document-api: openzaak
+                configurations:
+                    openzaak:
+                        url: http://localhost:10001
+                        clientId: valtimo_client
+                        secret: e09b8bc5-5831-4618-ab28-41411304309d
+                        rsin: "051845623"
+                        documentTypeUrl: http://localhost:8001/catalogi/api/v1/informatieobjecttypen/00000000-0000-0000-000000000000
+                    example:
+                        url: https://example.org/documenten/api/v1
+                        clientId: valtimo_client
+                        secret: e09b8bc5-5831-4618-ab28-111111111111
 
 logging:
     level:

--- a/zgw/besluiten/src/test/resources/graphql/schema.graphqls
+++ b/zgw/besluiten/src/test/resources/graphql/schema.graphqls
@@ -1,3 +1,6 @@
+type Query{
+    dummy: String
+}
 type Besluit {
     bestuursorgaan: String
     datum: Date!
@@ -15,7 +18,7 @@ type Besluit {
     zaak: String!
     auditTrails: [BesluitAuditTrail!]!
     besluittype: BesluitType!
-    documenten: [BesluitDocument!]!
+    documenten: [Document!]!
 }
 
 type BesluitAuditTrail {
@@ -79,6 +82,17 @@ type BesluitType {
     toelichting: String
     url: String!
     zaaktypen: [String!]!
+}
+
+type Document {
+    bestandsnaam: String
+    bestandsomvang: Int
+    creatiedatum: String
+    documentapi: String!
+    formaat: String
+    identificatie: String
+    titel: String
+    uuid: UUID!
 }
 
 scalar UUID

--- a/zgw/documenten-api/build.gradle.kts
+++ b/zgw/documenten-api/build.gradle.kts
@@ -23,6 +23,7 @@ val isLib = true
 dependencies {
 
     api(project(":core"))
+    api(project(":graphql"))
     api(project(":portal-authentication"))
     api(project(":zgw:common-ground-authentication"))
     api(project(":zgw:idtoken-authentication"))

--- a/zgw/documenten-api/src/main/resources/graphql/schema.graphqls
+++ b/zgw/documenten-api/src/main/resources/graphql/schema.graphqls
@@ -1,0 +1,10 @@
+type Document {
+    bestandsnaam: String
+    bestandsomvang: Int
+    creatiedatum: String
+    documentapi: String!
+    formaat: String
+    identificatie: String
+    titel: String
+    uuid: UUID!
+}

--- a/zgw/documenten-api/src/test/resources/graphql/schema.graphqls
+++ b/zgw/documenten-api/src/test/resources/graphql/schema.graphqls
@@ -1,0 +1,15 @@
+type Query{
+    dummy: String
+}
+type Document {
+    bestandsnaam: String
+    bestandsomvang: Int
+    creatiedatum: String
+    documentapi: String!
+    formaat: String
+    identificatie: String
+    titel: String
+    uuid: UUID!
+}
+
+scalar UUID

--- a/zgw/openproduct/src/main/kotlin/nl/nlportal/openproduct/autoconfigure/OpenProductAutoConfiguration.kt
+++ b/zgw/openproduct/src/main/kotlin/nl/nlportal/openproduct/autoconfigure/OpenProductAutoConfiguration.kt
@@ -16,14 +16,17 @@
 package nl.nlportal.openproduct.autoconfigure
 
 import nl.nlportal.commonground.authentication.AuthenticationMachtigingsDienstService
+import nl.nlportal.core.security.config.HttpSecurityConfigurer
 import nl.nlportal.core.ssl.ClientSslContextResolver
 import nl.nlportal.documentenapi.service.DocumentenApiService
 import nl.nlportal.openproduct.client.OpenProductClient
 import nl.nlportal.openproduct.client.OpenProductDmnClient
 import nl.nlportal.openproduct.client.OpenProductTypeClient
+import nl.nlportal.openproduct.security.config.ProductDocumentResourceHttpSecurityConfigurer
 import nl.nlportal.openproduct.service.OpenProductDmnService
 import nl.nlportal.openproduct.service.OpenProductService
 import nl.nlportal.zakenapi.client.ZakenApiClient
+import nl.nlportal.zakenapi.security.config.ZaakDocumentResourceHttpSecurityConfigurer
 import nl.nlportal.zgw.objectenapi.client.ObjectsApiClient
 import nl.nlportal.zgw.taak.autoconfigure.TaakConfig
 import org.springframework.beans.factory.annotation.Autowired
@@ -39,7 +42,7 @@ import org.springframework.web.reactive.function.client.WebClient
     OpenProductModuleConfiguration::class,
     TaakConfig::class,
 )
-@ConditionalOnProperty(prefix = "nl-portal.config", name = ["openproduct.enabled", "objectenapi.enabled", "taak.enabled", "zakenapi.enabled"], havingValue = "true")
+@ConditionalOnProperty(prefix = "nl-portal.config", name = ["openproduct.enabled", "objectenapi.enabled", "taak.enabled", "zakenapi.enabled", "documentenapis.enabled"], havingValue = "true")
 class OpenProductAutoConfiguration {
     @Bean
     @ConditionalOnMissingBean(OpenProductClient::class)
@@ -97,4 +100,8 @@ class OpenProductAutoConfiguration {
             openProductDmnClient = openProductDmnClient,
             openProductService = openProductService,
         )
+
+    @Bean
+    @ConditionalOnMissingBean(ProductDocumentResourceHttpSecurityConfigurer::class)
+    fun productDocumentResourceHttpSecurityConfigurer(): HttpSecurityConfigurer = ProductDocumentResourceHttpSecurityConfigurer()
 }

--- a/zgw/openproduct/src/main/kotlin/nl/nlportal/openproduct/security/config/ProductDocumentResourceHttpSecurityConfigurer.kt
+++ b/zgw/openproduct/src/main/kotlin/nl/nlportal/openproduct/security/config/ProductDocumentResourceHttpSecurityConfigurer.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2015-2024 Ritense BV, the Netherlands.
+ *
+ * Licensed under EUPL, Version 1.2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.nlportal.openproduct.security.config
+
+import nl.nlportal.core.security.config.HttpSecurityConfigurer
+import org.springframework.context.annotation.Configuration
+import org.springframework.http.HttpMethod.GET
+import org.springframework.security.config.web.server.ServerHttpSecurity
+
+@Configuration
+class ProductDocumentResourceHttpSecurityConfigurer : HttpSecurityConfigurer {
+    override fun configure(http: ServerHttpSecurity) {
+        http.authorizeExchange { authorize ->
+            authorize.pathMatchers(GET, "/api/product/{productId}/documentapi/{documentapi}/document/{documentId}/content").authenticated()
+        }
+    }
+}

--- a/zgw/openproduct/src/test/resources/graphql/schemas.graphqls
+++ b/zgw/openproduct/src/test/resources/graphql/schemas.graphqls
@@ -802,7 +802,7 @@ type Besluit {
     zaak: String!
     auditTrails: [BesluitAuditTrail!]!
     besluittype: BesluitType!
-    documenten: [BesluitDocument!]!
+    documenten: [Document!]!
 }
 
 type BesluitAuditTrail {

--- a/zgw/zaken-api/src/main/resources/graphql/schema.graphqls
+++ b/zgw/zaken-api/src/main/resources/graphql/schema.graphqls
@@ -123,15 +123,4 @@ type ResultaatType {
     zaaktypeIdentificatie: String
 }
 
-type Document {
-    bestandsnaam: String
-    bestandsomvang: Int
-    creatiedatum: String
-    documentapi: String!
-    formaat: String
-    identificatie: String
-    titel: String
-    uuid: UUID!
-}
-
 

--- a/zgw/zaken-api/src/test/kotlin/nl/nlportal/zakenapi/graphql/ZaakQueryIT.kt
+++ b/zgw/zaken-api/src/test/kotlin/nl/nlportal/zakenapi/graphql/ZaakQueryIT.kt
@@ -653,7 +653,17 @@ internal class ZaakQueryIT(
                         identificatie,
                         datum,
                         toelichting,
-                        publicatiedatum
+                        publicatiedatum,
+                        documenten {
+                            uuid,
+                            documentapi,
+                            identificatie,
+                            creatiedatum,
+                            titel,
+                            formaat,
+                            bestandsnaam,
+                            bestandsomvang
+                        }
                     },
                     resultaat{
                         toelichting,
@@ -836,7 +846,7 @@ internal class ZaakQueryIT(
                         identificatie,
                         datum,
                         toelichting,
-                        publicatiedatum
+                        publicatiedatum                      
                     }
                 }
             }
@@ -899,6 +909,7 @@ internal class ZaakQueryIT(
                             "/enkelvoudiginformatieobjecten/095be615-a8ad-4c33-8e9c-c7612fbf6c9f" -> handleDocumentRequest()
                             "/zaken/api/v1/rollen" -> handleZaakRollenRequest()
                             "/besluiten/api/v1/besluiten" -> handleBesluitenRequest()
+                            "/besluiten/api/v1/besluitinformatieobjecten" -> handleBesluitDocumentenRequest()
                             "/zaken/api/v1/substatussen" -> handleSubStatusListRequest()
                             "/zaken/api/v1/resultaten/095be615-a8ad-4c33-8e9c-c7612fbf6c9f" -> handleResultaatRequest()
                             "/catalogi/api/v1/resultaattypen/095be615-a8ad-4c33-8e9c-c7612fbf6c9f" -> handleResultaatTypeRequest()
@@ -1407,6 +1418,21 @@ internal class ZaakQueryIT(
                 }
               ]
             }
+            """.trimIndent()
+
+        return mockResponse(body)
+    }
+
+    fun handleBesluitDocumentenRequest(): MockResponse {
+        val body =
+            """
+            [
+              {
+                "url": "$url/enkelvoudiginformatieobjecten/095be615-a8ad-4c33-8e9c-c7612fbf6c9f",
+                "informatieobject": "$url/enkelvoudiginformatieobjecten/095be615-a8ad-4c33-8e9c-c7612fbf6c9f",
+                "besluit": "$url/besluiten/api/v1/besluiten/496f51fd-ccdb-406e-805a-e7602ae78a2z"
+              }
+            ]
             """.trimIndent()
 
         return mockResponse(body)

--- a/zgw/zaken-api/src/test/resources/graphql/schema.graphqls
+++ b/zgw/zaken-api/src/test/resources/graphql/schema.graphqls
@@ -152,7 +152,7 @@ type Besluit {
     zaak: String!
     auditTrails: [BesluitAuditTrail!]!
     besluittype: BesluitType!
-    documenten: [BesluitDocument!]!
+    documenten: [Document!]
 }
 
 type BesluitAuditTrail {


### PR DESCRIPTION
- Moved document schema to the documentapis module. Added some HttpSecurityConfigurer (besluiten/openproduct)
- download endpoint: /api/besluiten/{besluitId}/document/{documentId}/content
